### PR TITLE
Bug/fakerservicexmldefaultfieldtype

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "salesforce-data-treecipe",
   "displayName": "Salesforce Data Treecipe",
   "description": "source-fidelity driven development, pairs well with cumulus-ci",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
         "properties": {
           "salesforce-data-treecipe.selectedFakerService" : {
             "type": "string",
-            "description": "faker implementation chosen as part of treecipe config setup and selections"
+            "description": "faker implementation chosen as part of treecipe config setup and selections",
+            "default": "snowfakery"
           },
           "salesforce-data-treecipe.treecipeConfigurationPath" : {
             "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,7 @@ import { ExtensionCommandService } from './treecipe/src/ExtensionCommandService/
 // Your extension is activated the very first time the command is executed
 export async function activate(context: vscode.ExtensionContext) {
 
-	// below set config value of "useSnowfakeryAsDefault" will be used until an implementation is 
-	// built fully for faker-js
+	// below set config value of "useSnowfakeryAsDefault" will be used until an implementation is built fully for faker-js
 	ConfigurationService.setExtensionConfigValue('useSnowfakeryAsDefault', true);
 
 	const initiateConfiguration = vscode.commands.registerCommand('treecipe.initiateConfiguration', () => {

--- a/src/treecipe/src/ConfigurationService/ConfigurationService.ts
+++ b/src/treecipe/src/ConfigurationService/ConfigurationService.ts
@@ -83,7 +83,7 @@ export class ConfigurationService {
 
         let selectedDataFakerService = null;
         if ( this.getExtensionConfigValue('useSnowfakeryAsDefault')) {
-            selectedDataFakerService = "Snowfakery";
+            selectedDataFakerService = "snowfakery";
         } else {
             selectedDataFakerService = await VSCodeWorkspaceService.promptForFakerServiceImplementation();
             if (!selectedDataFakerService) {
@@ -125,7 +125,7 @@ export class ConfigurationService {
         const selectedFakerServiceKey = "selectedFakerService";
         const fakerConfigurationSelection = this.getExtensionConfigValue(selectedFakerServiceKey);
         switch (fakerConfigurationSelection) {
-            case 'Snowfakery':
+            case 'snowfakery':
               return new SnowfakeryFakerService();
             case 'faker-js':
               return new NPMFakerService();

--- a/src/treecipe/src/ConfigurationService/tests/ConfigurationService.test.ts
+++ b/src/treecipe/src/ConfigurationService/tests/ConfigurationService.test.ts
@@ -11,7 +11,7 @@ jest.mock('vscode', () => ({
         getConfiguration: jest.fn(() => ({
             get: jest.fn((key) => {
                 const mockConfig = {
-                    selectedFakerService: 'Snowfakery', // Replace with mock key-value pairs as needed
+                    selectedFakerService: 'snowfakery', // Replace with mock key-value pairs as needed
                 };
                 return mockConfig[key];
             }),
@@ -38,7 +38,7 @@ describe('Shared ConfigurationService Tests', () => {
           
             const requiredInterfaceConfigKeyToMockValue = "selectedFakerService";
             const actualMockedExtensionConfigValue = ConfigurationService.getExtensionConfigValue(requiredInterfaceConfigKeyToMockValue);
-            const expectedMockedExtensionConfigValue = "Snowfakery";
+            const expectedMockedExtensionConfigValue = "snowfakery";
             expect(actualMockedExtensionConfigValue).toBe(expectedMockedExtensionConfigValue);
         
         });
@@ -112,7 +112,7 @@ describe('Shared ConfigurationService Tests', () => {
 
             const expectedConfigJson = `{
     "salesforceObjectsPath": "/mock/objects/path",
-    "dataFakerService": "Snowfakery"
+    "dataFakerService": "snowfakery"
 }`;
             expect(fs.writeFileSync).toHaveBeenCalledWith(`${mockWorkspaceRoot}/${mockTreecipeBaseDir}/${mockConfigFileName}`, expectedConfigJson);
 
@@ -130,14 +130,14 @@ describe('Shared ConfigurationService Tests', () => {
             
             const expectedConfigDetailJson = `{
     "salesforceObjectsPath": "/mock/objects/path",
-    "dataFakerService": "Snowfakery"
+    "dataFakerService": "snowfakery"
 }`;
 
             jest.spyOn(fs, 'readFileSync').mockReturnValue(expectedConfigDetailJson);
             jest.spyOn(ConfigurationService, 'setExtensionConfigValue').mockReturnValue();
 
             const actualTreecipeConfiguratoinDetail = ConfigurationService.getTreecipeConfigurationDetail();
-            expect(actualTreecipeConfiguratoinDetail.dataFakerService).toBe("Snowfakery");
+            expect(actualTreecipeConfiguratoinDetail.dataFakerService).toBe("snowfakery");
         });
 
     });
@@ -150,7 +150,7 @@ describe('Shared ConfigurationService Tests', () => {
 
             const expectedConfigDetailJson = `{
     "salesforceObjectsPath": "${mockObjectsPath}",
-    "dataFakerService": "Snowfakery"
+    "dataFakerService": "snowfakery"
 }`;
             
             jest.spyOn(fs, 'readFileSync').mockReturnValue(expectedConfigDetailJson);

--- a/src/treecipe/src/RecipeService/RecipeService.ts
+++ b/src/treecipe/src/RecipeService/RecipeService.ts
@@ -61,20 +61,27 @@ export class RecipeService {
             //     return 'test';
                 
             default: 
-                const fieldToRecipeValueMap = this.fakerService.getMapSalesforceFieldToFakerValue;
-                // CHECK IF VALID FIELD TYPE OR EXISTS IN PROGRAMS SALESFORCE FIELD MAP
-                if ( fieldType in fieldToRecipeValueMap ) {
-                    fakeRecipeValue = fieldToRecipeValueMap[fieldType];
-                } else {
-                    // NOT THROWING EXCEPTION HERE, WE WANT THE REMAINING FIELDS TO BE PROCESSED
-                    fakeRecipeValue = `"FieldType Not Handled -- ${fieldType} does not exist in this programs Salesforce field map."`;
-                }
 
+                fakeRecipeValue = this.getFakeValueIfExpectedSalesforceFieldType(fieldType);
                 return fakeRecipeValue;
-            
 
         }
 
+    }
+    
+    getFakeValueIfExpectedSalesforceFieldType(fieldType:string):string {
+        let recipeValue = null;
+        const fieldToRecipeValueMap:Record<string, string> = this.fakerService.getMapSalesforceFieldToFakerValue();
+        // CHECK IF VALID FIELD TYPE OR EXISTS IN PROGRAMS SALESFORCE FIELD MAP
+        if ( fieldType in fieldToRecipeValueMap ) {
+            recipeValue = fieldToRecipeValueMap[fieldType];
+        } else {
+            // NOT THROWING EXCEPTION HERE, WE WANT THE REMAINING FIELDS TO BE PROCESSED
+            recipeValue = `"FieldType Not Handled -- ${fieldType} does not exist in this programs Salesforce field map."`;
+        }    
+
+        return recipeValue;
+    
     }
 
     getDependentPicklistRecipeFakerValue(xmlFieldDetail: XMLFieldDetail): string {

--- a/src/treecipe/src/RecipeService/tests/RecipeService.test.ts
+++ b/src/treecipe/src/RecipeService/tests/RecipeService.test.ts
@@ -59,6 +59,56 @@ jest.mock('vscode', () => ({
 
         });
 
+        test('given expected datetime XMLFieldDetail, returns the expected snowfakery YAML recipe value', () => {
+
+            const expectedDatetimeXMLFieldDetail:XMLFieldDetail = XMLMarkupMockService.getDateTimeFieldDetail();
+            const expectedDatetimeSnowfakeryValue = '${{fake.date_time_between(start_date="-1y", end_date="now")}}';
+            const actualDatetimeSnowfakeryValue = recipeServiceWithSnow.getRecipeFakeValueByXMLFieldDetail(expectedDatetimeXMLFieldDetail);
+
+            expect(actualDatetimeSnowfakeryValue).toBe(expectedDatetimeSnowfakeryValue);
+
+        });
+
+        test('given expected url XMLFieldDetail, returns the expected snowfakery YAML recipe value', () => {
+
+            const expectedUrlFieldDetail:XMLFieldDetail = XMLMarkupMockService.getUrlXMLFieldDetail();
+            const expectedUrlSnowfakeryValue = '${{fake.url()}}';
+            const actualUrlSnowfakeryValue = recipeServiceWithSnow.getRecipeFakeValueByXMLFieldDetail(expectedUrlFieldDetail);
+
+            expect(actualUrlSnowfakeryValue).toBe(expectedUrlSnowfakeryValue);
+
+        });
+
+        test('given expected phone XMLFieldDetail, returns the expected snowfakery YAML recipe value', () => {
+
+            const expectedXMLDetailForPhone:XMLFieldDetail = XMLMarkupMockService.getPhoneXMLFieldDetail();
+            const expectedSnowfakeryValueForPhone = '${{fake.phone_number()}}';
+            const actualSnowfakeryValueForPhone = recipeServiceWithSnow.getRecipeFakeValueByXMLFieldDetail(expectedXMLDetailForPhone);
+
+            expect(actualSnowfakeryValueForPhone).toBe(expectedSnowfakeryValueForPhone);
+
+        });
+
+        test('given expected number XMLFieldDetail, returns the expected snowfakery YAML recipe value', () => {
+
+            const expectedXMLDetailForNumber:XMLFieldDetail = XMLMarkupMockService.getNumberXMLFieldDetail();
+            const expectedSnowfakeryValueForNumber = '${{fake.random_int(min=0, max=999999)}}';
+            const actualSnowfakeryValueForNumber = recipeServiceWithSnow.getRecipeFakeValueByXMLFieldDetail(expectedXMLDetailForNumber);
+
+            expect(actualSnowfakeryValueForNumber).toBe(expectedSnowfakeryValueForNumber);
+
+        });
+
+        test('given expected currency XMLFieldDetail, returns the expected snowfakery YAML recipe value', () => {
+
+            const expectedXMLDetailForCurrency:XMLFieldDetail = XMLMarkupMockService.getCurrencyFieldDetail();
+            const expectedSnowfakeryValueForCurrency = '${{fake.pydecimal(left_digits=6, right_digits=2, positive=True)}}';
+            const actualSnowfakeryValueForCurrency = recipeServiceWithSnow.getRecipeFakeValueByXMLFieldDetail(expectedXMLDetailForCurrency);
+
+            expect(actualSnowfakeryValueForCurrency).toBe(expectedSnowfakeryValueForCurrency);
+
+        });
+
     });
 
     describe('initiateRecipeByObjectName', () => {
@@ -165,14 +215,27 @@ jest.mock('vscode', () => ({
                 controllingField : "Town__c"
             };
  
-           
-
             const expectedDependentListFakeValue = RecipeMockService.getMockSnowfakeryDependentPicklistRecipeValue();
             const actualRecipeValue = recipeServiceWithSnow.getDependentPicklistRecipeFakerValue(expectedXMLFieldDetail);
 
             expect(actualRecipeValue).toBe(expectedDependentListFakeValue);
 
         });
+    });
+
+    describe('getFakeValueIfExpectedSalesforceFieldType', () => {
+
+        test('given expected fieldToRecipeValueMap and fieldtypes, returns the expected snowfakery YAML recipe value', () => {
+
+            const expectedFieldToRecipeValue = snowFakerService.getMapSalesforceFieldToFakerValue();
+            for ( const fieldTypeKey in expectedFieldToRecipeValue ) {
+                const recipeValue = expectedFieldToRecipeValue[fieldTypeKey];
+                const actualRecipeValue = recipeServiceWithSnow.getFakeValueIfExpectedSalesforceFieldType(fieldTypeKey);
+                expect(actualRecipeValue).toBe(recipeValue);
+            }
+            
+        });
+
     });
 
 });

--- a/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts
+++ b/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts
@@ -108,7 +108,7 @@ export class VSCodeWorkspaceService {
         
         let items: vscode.QuickPickItem[] = [
             {
-                label: 'Snowfakery',
+                label: 'snowfakery',
                 description: 'CumulusCI Python port of Faker - https://snowfakery.readthedocs.io/en/latest/',
                 iconPath: new vscode.ThemeIcon('database')
             },

--- a/src/treecipe/src/VSCodeWorkspace/tests/VSCodeWorkspaceService.test.ts
+++ b/src/treecipe/src/VSCodeWorkspace/tests/VSCodeWorkspaceService.test.ts
@@ -56,7 +56,7 @@ describe('promptForObjectsPath', () => {
         expect(showQuickPickSpy).toHaveBeenCalledWith(
             [
                 {
-                    label: 'Snowfakery',
+                    label: 'snowfakery',
                     description: 'CumulusCI Python port of Faker - https://snowfakery.readthedocs.io/en/latest/',
                     iconPath: expect.any(Object)
                 },


### PR DESCRIPTION
## Pull Request Description

Recent refactoring left out invoke parenthesis on SalesforceFieldTypeMap causing field type recipe values to not be populated 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

### What does this PR do?

- updates the bug fix along with associated jidoka ( countermeasure) tests to validate this scenario occurring again or not
- fix potential casing issues with selected faker service type when snowfakery

### Motivation and Context
bug caused by refactor

### How Has This Been Tested?
- [ ] Tested on Windows
- [x] Tested on macOS
- [ ] Tested on Linux
- [x] Added new unit tests
- [x] Updated existing tests

#### Test Details

- New unit testing captures abstracted method of logic that was previously failing. This function now has dedicated tests that loop over all expected fieldtypes and returns expected recipe value

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Additional Notes
n/a

### Reviewers
@mention-team-members-or-specific-reviewers