### PR TITLE
Bug/recordtype dependent picklist markup bug

### DIFF
--- a/src/treecipe/src/FakerService/SnowfakeryFakerService/SnowfakeryFakerService.ts
+++ b/src/treecipe/src/FakerService/SnowfakeryFakerService/SnowfakeryFakerService.ts
@@ -157,9 +157,15 @@ ${this.generateTabs(5)}${randomChoicesBreakdown}`;
 
             const noPicklistValuesForRecordTypeVerbiage = `${newLineBreak}${this.generateTabs(5)}### TODO: -- RecordType Options -- ${recordTypeApiNameKey} -- "${controllingValue}" is not an available value for ${controllingFieldApiName} for record type ${recordTypeApiNameKey}`;
 
-            if ( !availableRecordTypePicklistValuesForControllingField.includes(controllingValue) ) {
-                // picklist value not available for record type so no dependent picklist values to process
+            if ( !availableRecordTypePicklistValuesForControllingField || !availableRecordTypePicklistValuesForControllingField.includes(controllingValue) ) {
+  
+                /*
+                    EITHER
+                     - picklist value not available for record type so no dependent picklist values to process
+                     - controlling api field doesn't exist in record type markup so no dependent picklist values to process
+                */
                 allRecordTypeChoicesBreakdown += noPicklistValuesForRecordTypeVerbiage;
+                
             } else {
 
                 let recordTypeChoicesBreakdown:string;

--- a/src/treecipe/src/FakerService/SnowfakeryFakerService/tests/SnowfakeryFakerService.test.ts
+++ b/src/treecipe/src/FakerService/SnowfakeryFakerService/tests/SnowfakeryFakerService.test.ts
@@ -309,12 +309,12 @@ describe('SnowfakeryFakerService Shared Intstance Tests', () => {
                                                                                                 controllingFieldValue
                                                                                             );
 
-            const madisonControllingValueToPicklistOptions = MockRecordTypeService.getNotAvailableControllingValueToDependentPicklistOptionsVerbiageBasedOnExpectedRecordTypes(controllingFieldValue, controllingFieldApiName);
-            expect(actualUpdatedRandomChoicesBreakdown).toBe(madisonControllingValueToPicklistOptions);
+            const expectedRecordTypeControllingValueToPicklistOptionsFakerValue = MockRecordTypeService.getNotAvailableControllingValueToDependentPicklistOptionsVerbiageBasedOnExpectedRecordTypes(controllingFieldValue, controllingFieldApiName);
+            expect(actualUpdatedRandomChoicesBreakdown).toBe(expectedRecordTypeControllingValueToPicklistOptionsFakerValue);
         
         });
 
-        test('given no record type associated xml markup, "no record type selections" verbiage is added to recipe value', () => {
+        test('given expected record type files but no record type associated xml markup, "no record type selections" verbiage is added to recipe value', () => {
             
             const expectedRecordTypeDeveloperNameToRecordTypeWrapperMap = MockRecordTypeService.getMultipleRecordTypeToFieldToRecordTypeWrapperMap();
             const fakeFieldApiName = "DependentPicklist__c";
@@ -329,8 +329,28 @@ describe('SnowfakeryFakerService Shared Intstance Tests', () => {
                                                                                                 controllingFieldValue
                                                                                             );
 
-            const madisonControllingValueToPicklistOptions = MockRecordTypeService.getNotAvailableControllingValueToDependentPicklistOptionsVerbiageBasedOnExpectedRecordTypes(controllingFieldValue, controllingFieldApiName);
-            expect(actualUpdatedRandomChoicesBreakdown).toBe(madisonControllingValueToPicklistOptions);
+            const expectedRecordTypeControllingValueToPicklistOptionsFakerValue = MockRecordTypeService.getNotAvailableControllingValueToDependentPicklistOptionsVerbiageBasedOnExpectedRecordTypes(controllingFieldValue, controllingFieldApiName);
+            expect(actualUpdatedRandomChoicesBreakdown).toBe(expectedRecordTypeControllingValueToPicklistOptionsFakerValue);
+        
+        });
+
+        test('given NO record type files at all, no record type verbiage is added to recipe value', () => {
+            
+            const noRecordTypeDeveloperNameToRecordTypeWrapperMap = {};
+            const fakeFieldApiName = "DependentPicklist__c";
+            const controllingFieldValue = 'madison';
+            const controllingFieldApiName = 'apiFieldThatDoesntExistInAnyRecordTypeXMLMarkup';
+
+    
+            const actualUpdatedRandomChoicesBreakdown = snowfakeryService.updateDependentPicklistRecipeFakerValueByRecordTypeSections(
+                                                                                                noRecordTypeDeveloperNameToRecordTypeWrapperMap, 
+                                                                                                fakeFieldApiName, 
+                                                                                                controllingFieldApiName,
+                                                                                                controllingFieldValue
+                                                                                            );
+
+            const expectedRecordTypeControllingValueToPicklistOptionsFakerValue = "";
+            expect(actualUpdatedRandomChoicesBreakdown).toBe(expectedRecordTypeControllingValueToPicklistOptionsFakerValue);
         
         });
     

--- a/src/treecipe/src/FakerService/SnowfakeryFakerService/tests/SnowfakeryFakerService.test.ts
+++ b/src/treecipe/src/FakerService/SnowfakeryFakerService/tests/SnowfakeryFakerService.test.ts
@@ -309,7 +309,27 @@ describe('SnowfakeryFakerService Shared Intstance Tests', () => {
                                                                                                 controllingFieldValue
                                                                                             );
 
-            const madisonControllingValueToPicklistOptions = MockRecordTypeService.getMadisonControllingValueToDependentPicklistOptions();
+            const madisonControllingValueToPicklistOptions = MockRecordTypeService.getNotAvailableControllingValueToDependentPicklistOptionsVerbiageBasedOnExpectedRecordTypes(controllingFieldValue, controllingFieldApiName);
+            expect(actualUpdatedRandomChoicesBreakdown).toBe(madisonControllingValueToPicklistOptions);
+        
+        });
+
+        test('given no record type associated xml markup, "no record type selections" verbiage is added to recipe value', () => {
+            
+            const expectedRecordTypeDeveloperNameToRecordTypeWrapperMap = MockRecordTypeService.getMultipleRecordTypeToFieldToRecordTypeWrapperMap();
+            const fakeFieldApiName = "DependentPicklist__c";
+            const controllingFieldValue = 'madison';
+            const controllingFieldApiName = 'apiFieldThatDoesntExistInAnyRecordTypeXMLMarkup';
+
+    
+            const actualUpdatedRandomChoicesBreakdown = snowfakeryService.updateDependentPicklistRecipeFakerValueByRecordTypeSections(
+                                                                                                expectedRecordTypeDeveloperNameToRecordTypeWrapperMap, 
+                                                                                                fakeFieldApiName, 
+                                                                                                controllingFieldApiName,
+                                                                                                controllingFieldValue
+                                                                                            );
+
+            const madisonControllingValueToPicklistOptions = MockRecordTypeService.getNotAvailableControllingValueToDependentPicklistOptionsVerbiageBasedOnExpectedRecordTypes(controllingFieldValue, controllingFieldApiName);
             expect(actualUpdatedRandomChoicesBreakdown).toBe(madisonControllingValueToPicklistOptions);
         
         });

--- a/src/treecipe/src/RecordTypeService/RecordTypeService.ts
+++ b/src/treecipe/src/RecordTypeService/RecordTypeService.ts
@@ -34,7 +34,7 @@ export class RecordTypeService {
         for (const [fileName, directoryItemTypeEnum] of recordTypeFileTuples) {
     
           if ( XmlFileProcessor.isXMLFileType(fileName, directoryItemTypeEnum) ) {
-    
+
             const recordTypeUri = vscode.Uri.joinPath(recordTypesDirectoryUri, fileName);
             const recordTypeContentUriData = await vscode.workspace.fs.readFile(recordTypeUri);
             const recordTypeXMLContent = Buffer.from(recordTypeContentUriData).toString('utf8');

--- a/src/treecipe/src/RecordTypeService/tests/MockRecordTypeService.ts
+++ b/src/treecipe/src/RecordTypeService/tests/MockRecordTypeService.ts
@@ -277,20 +277,17 @@ export class MockRecordTypeService {
     
     }
 
-    static getMadisonControllingValueToDependentPicklistOptions():string {
+    static getNotAvailableControllingValueToDependentPicklistOptionsVerbiageBasedOnExpectedRecordTypes(controllingFieldValue: string, controllingFieldApiName: string):string {
 
         const recordTypeOneRecTypeApiNameKey = 'OneRecType';
         const recordTypeTwoRecTypeApiNameKey = 'TwoRecType';
 
-        const controllingValue = "madison";
-        const controllingFieldApiName = "Picklist__c";
-
-        const madisionControllingValueToPicklistOptions =       
+        const expectedControllingValueToPicklistOptions =       
         `
-                    ### TODO: -- RecordType Options -- ${recordTypeOneRecTypeApiNameKey} -- "${controllingValue}" is not an available value for ${controllingFieldApiName} for record type ${recordTypeOneRecTypeApiNameKey}
-                    ### TODO: -- RecordType Options -- ${recordTypeTwoRecTypeApiNameKey} -- "${controllingValue}" is not an available value for ${controllingFieldApiName} for record type ${recordTypeTwoRecTypeApiNameKey}`;
+                    ### TODO: -- RecordType Options -- ${recordTypeOneRecTypeApiNameKey} -- "${controllingFieldValue}" is not an available value for ${controllingFieldApiName} for record type ${recordTypeOneRecTypeApiNameKey}
+                    ### TODO: -- RecordType Options -- ${recordTypeTwoRecTypeApiNameKey} -- "${controllingFieldValue}" is not an available value for ${controllingFieldApiName} for record type ${recordTypeTwoRecTypeApiNameKey}`;
 
-        return madisionControllingValueToPicklistOptions;
+        return expectedControllingValueToPicklistOptions;
     
     }
 

--- a/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
+++ b/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
@@ -80,7 +80,9 @@ export class XmlFileProcessor {
 
       if ( picklistValueSetMarkup.controllingField ) {
         // IF THERE IS A CONTROLLING FIELD THEN WE CAN EXPECT THERE TO BE A DEPENDENT PICKLIST AND CONTROLLING FIELD VALUE SETTINGS
-        let availableForControllingValuesForPicklistOption = picklistValueSetMarkup.valueSettings.filter( (dependentPicklistSetting) => dependentPicklistSetting.valueName[0] === picklistApiFullName);
+        let availableForControllingValuesForPicklistOption = picklistValueSetMarkup.valueSettings.filter( 
+          (dependentPicklistSetting) => dependentPicklistSetting.valueName[0] === picklistApiFullName
+        );
         if (availableForControllingValuesForPicklistOption) {
           let availableForControllingValuesettings:string[] = availableForControllingValuesForPicklistOption[0].controllingFieldValue;
           picklistDetail.availableForControllingValues = availableForControllingValuesettings;


### PR DESCRIPTION
### Motivation and Context

This change represents a bug fix reported here: https://github.com/jdschleicher/Salesforce-Data-Treecipe/issues/11 

### What does this PR do?

When processing xml markup to generate a "faker" value, there can be a dependency on record type markup for the associated object of the field being processed.  

The bug stemmed from an unchecked assumption that a dependent picklist field WOULD NOT exist in the record type markup. This caused an error in downstream logic that expected the record type xml to exist when generating the faker value. 

This bug would also occur even in the most basic scenario of a record type file not existing at all and a dependent picklist would try to find associated information in record type markup that never existing to begin with. 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):


### How Has This Been Tested?
- [ ] Tested on Windows
- [x] Tested on macOS
- [ ] Tested on Linux
- [x] Added new unit tests
- [x] Updated existing tests

#### Test Details

- tested with scenarios of no record types for object, record type without markup of controlling field api name, and original logic for record type xml markup with expected controlling field api value set info

### Checklist
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Additional Notes
n/a

### Reviewers
n/a