### PR TITLE
Feature/field processor error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,24 @@
 # Change Log
 
-## [2.0.4] [PR#19](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/21) - Bug: 2.0.0
+## [2.1.0] [PR#25](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/25) - Feature and Bug Fix: 2.1.0
+
+When generating recipes error handling was not granular and provided no specific detail into what Salesforce field in the local project base was causing an issue. This functionality wraps the field processing service in a try/catch and generates a error details page for self-service troubleshooting.
+
+BUGFIX - as part of this work, there was a bug discovered for dependent picklists and global picklist markup. This update provides functionality that provides necessary logic to prevent recipe generation failure at run time.
+
+## [2.0.4] [PR#21](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/21) - Bug: 2.0.4
 
 Fix for extension error "Command Not Found" -- added "faker-js" into package.json dependencies instead of devDependencies configuriation
 
-## [2.0.3] [PR#18](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/19) - Bug: 2.0.0
+## [2.0.3] [PR#18](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/19) - Bug: 2.0.3
 
 Third attempt to fix issue with "Command Not Found"
 
-## [2.0.2] [PR#18](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/18) - Bug: 2.0.0
+## [2.0.2] [PR#18](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/18) - Bug: 2.0.2
 
 Second attempt to fix issue with "Command Not Found"
 
-## [2.0.1] [PR#17](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/17) - Bug: 2.0.0
+## [2.0.1] [PR#17](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/17) - Bug: 2.0.1
 
 Attempting to fix issue with "Command Not Found"
 

--- a/extensionDevelopmentScriptsAndArtifacts/treecipe/GeneratedRecipes/recipe-2025-01-03T15-45-06-fakerjs.yaml
+++ b/extensionDevelopmentScriptsAndArtifacts/treecipe/GeneratedRecipes/recipe-2025-01-03T15-45-06-fakerjs.yaml
@@ -29,7 +29,7 @@
     CustomerPriority__c: "${{ faker.helpers.arrayElement(['High','Low','Medium']) }}"
     Number_of_Contacts__c: "${{ faker.number.int({min: 0, max: 999999}) }}"
     SLAExpirationDate__c: "${{ faker.date.between({ from: new Date('2023-01-01'), to: new Date() }).toISOString().split('T')[0] }}"
-    SLASerialNumber__c: "${{ faker.lorem.text(50) }}"
+    SLASerialNumber__c: "${{ faker.lorem.text(5).substring(0, 255)  }}"
     SLA__c: "${{ faker.helpers.arrayElement(['Gold','Silver','Platinum','Bronze']) }}"
     UpsellOpportunity__c: "${{ faker.helpers.arrayElement(['Maybe','No','Yes']) }}"
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Salesforce Data Treecipe",
   "description": "source-fidelity driven development, pairs well with cumulus-ci",
   "icon": "images/datatreecipe.webp",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts
+++ b/src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts
@@ -113,7 +113,9 @@ export class DirectoryProcessor {
 
         let fieldInfo = await this.buildFieldInfoByXMLContent(fieldXmlContent, 
                                                               associatedObjectName, 
-                                                              recordTypeApiToRecordTypeWrapperMap);
+                                                              recordTypeApiToRecordTypeWrapperMap,
+                                                              fileName
+                                                            );
         fieldInfoDetails.push(fieldInfo);
 
       }
@@ -126,10 +128,11 @@ export class DirectoryProcessor {
 
   async buildFieldInfoByXMLContent(xmlContent: string, 
                                     associatedObjectName: string,
-                                    recordTypeApiToRecordTypeWrapperMap: Record<string, RecordTypeWrapper>
+                                    recordTypeApiToRecordTypeWrapperMap: Record<string, RecordTypeWrapper>,
+                                    xmlFieldFileName: string
                                   ):Promise<FieldInfo> {
 
-    let fieldXMLDetail: XMLFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlContent);
+    let fieldXMLDetail: XMLFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlContent, xmlFieldFileName);
     let recipeValue = this.getRecipeValueByFieldXMLDetail(fieldXMLDetail, recordTypeApiToRecordTypeWrapperMap);                                                        
 
     let fieldInfo = FieldInfo.create(

--- a/src/treecipe/src/DirectoryProcessingService/tests/DirectoryProcessor.test.ts
+++ b/src/treecipe/src/DirectoryProcessingService/tests/DirectoryProcessor.test.ts
@@ -100,7 +100,8 @@ describe('Shared DirectoryProcessor Snowfakery FakerService Implementation Testi
       const textXMLContent = XMLMarkupMockService.getTextFieldTypeXMLMarkup();
       const fakeObjectApiName = 'Demming';
       const recordTypeNameByRecordTypeNameToXMLMarkup = {};
-      let actualFieldInfo = await directoryProcessor.buildFieldInfoByXMLContent(textXMLContent, fakeObjectApiName, recordTypeNameByRecordTypeNameToXMLMarkup);
+      const fakeFieldApiName = 'fakeField';
+      let actualFieldInfo = await directoryProcessor.buildFieldInfoByXMLContent(textXMLContent, fakeObjectApiName, recordTypeNameByRecordTypeNameToXMLMarkup, fakeFieldApiName);
 
       const expectedFieldInfo = XMLMarkupMockService.getTextXMLFieldDetail();
     

--- a/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/fields/GlobalValuePicklist__c.field-meta.xml
+++ b/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/fields/GlobalValuePicklist__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>GlobalValuePicklist__c</fullName>
+    <description>the world</description>
+    <externalId>false</externalId>
+    <inlineHelpText>the world</inlineHelpText>
+    <label>GlobalValuePicklist</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>CLEGlobal</valueSetName>
+    </valueSet>
+</CustomField>

--- a/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/recordTypes/OneRecType.recordType-meta.xml
+++ b/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/recordTypes/OneRecType.recordType-meta.xml
@@ -23,6 +23,29 @@
         </values>
     </picklistValues>
     <picklistValues>
+        <picklist>GlobalValuePicklist__c</picklist>
+        <values>
+            <fullName>browns%2C</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>cavs%2C</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>crunch</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>guardians%2C</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>monsters%2C</fullName>
+            <default>false</default>
+        </values>
+    </picklistValues>
+    <picklistValues>
         <picklist>MultiPicklist__c</picklist>
         <values>
             <fullName>chorizo</fullName>

--- a/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/recordTypes/TwoRecType.recordType-meta.xml
+++ b/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/recordTypes/TwoRecType.recordType-meta.xml
@@ -23,6 +23,29 @@
         </values>
     </picklistValues>
     <picklistValues>
+        <picklist>GlobalValuePicklist__c</picklist>
+        <values>
+            <fullName>browns%2C</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>cavs%2C</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>crunch</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>guardians%2C</fullName>
+            <default>false</default>
+        </values>
+        <values>
+            <fullName>monsters%2C</fullName>
+            <default>false</default>
+        </values>
+    </picklistValues>
+    <picklistValues>
         <picklist>MultiPicklist__c</picklist>
         <values>
             <fullName>chicken</fullName>

--- a/src/treecipe/src/ErrorHandlingService/ErrorHandlingService.ts
+++ b/src/treecipe/src/ErrorHandlingService/ErrorHandlingService.ts
@@ -160,7 +160,7 @@ ${stackTrace}
             } 
         });
 
-        vscode.window.showWarningMessage('XMLFileProcessor error captured in file: ' + recipeErrorGenerationFileName, );
+        VSCodeWorkspaceService.showWarningMessage('XMLFileProcessor error captured in file: ' + recipeErrorGenerationFileName, );
         VSCodeWorkspaceService.openFileInEditor(outputFilePath);
     
     }
@@ -191,7 +191,7 @@ ${stackTrace}
             } 
         });
 
-        vscode.window.showWarningMessage('XMLFileProcessor error captured in file: ' + recipeErrorGenerationFileName, );
+        VSCodeWorkspaceService.showWarningMessage('XMLFileProcessor error captured in file: ' + recipeErrorGenerationFileName, );
         VSCodeWorkspaceService.openFileInEditor(outputFilePath);
 
     }
@@ -226,7 +226,7 @@ ${stackTrace}
             } 
         });
 
-        vscode.window.showWarningMessage('faker-js expression error captured in: ' + executedCommand );
+        VSCodeWorkspaceService.showWarningMessage('faker-js expression error captured in: ' + executedCommand );
         VSCodeWorkspaceService.openFileInEditor(outputFilePath);
 
     }

--- a/src/treecipe/src/ErrorHandlingService/ErrorHandlingService.ts
+++ b/src/treecipe/src/ErrorHandlingService/ErrorHandlingService.ts
@@ -200,4 +200,39 @@ ${stackTrace}
         return 'RecipeGenerationErrors';
     }
 
+    static createFakerExpressionEvaluationErrorCaptureFile(customFakerExpressionEvaluationValueError: Error, executedCommand: string) {
+    
+        // ensure dedicated directory for generated recipes exists
+        const workspaceRoot = VSCodeWorkspaceService.getWorkspaceRoot();
+        const generatedRecipesFolderName = ConfigurationService.getGeneratedRecipesDefaultFolderName();
+
+        const errorsGenerationFolderName = this.getFakerJSExpressionErrorsFolderName();
+        const expectedErrorsFolderPath = `${workspaceRoot}/treecipe/${generatedRecipesFolderName}/${errorsGenerationFolderName}`;
+        if (!fs.existsSync(expectedErrorsFolderPath)) {
+            fs.mkdirSync(expectedErrorsFolderPath, { recursive: true });
+        }
+    
+        const isoDateTimestamp = VSCodeWorkspaceService.getNowIsoDateTimestamp();
+        
+        let recipeErrorGenerationFileName = 'fakerJSExpressionError' + isoDateTimestamp + '.json';
+
+        const outputFilePath = `${expectedErrorsFolderPath}/${recipeErrorGenerationFileName}`;
+        
+        const jsonErrorDetail = JSON.stringify(customFakerExpressionEvaluationValueError, null, 2);
+        
+        fs.writeFile(outputFilePath, jsonErrorDetail, (error) => {
+            if (error) {
+                throw new Error(`an error occurred when creating file to capture faker-js evaluation for ${customFakerExpressionEvaluationValueError.message}.`);
+            } 
+        });
+
+        vscode.window.showWarningMessage('faker-js expression error captured in: ' + executedCommand );
+        VSCodeWorkspaceService.openFileInEditor(outputFilePath);
+
+    }
+
+    static getFakerJSExpressionErrorsFolderName() {
+        return 'FakerJSExpressionErrors';
+    }
+
 }

--- a/src/treecipe/src/ErrorHandlingService/ErrorHandlingService.ts
+++ b/src/treecipe/src/ErrorHandlingService/ErrorHandlingService.ts
@@ -1,4 +1,7 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import { ConfigurationService } from '../ConfigurationService/ConfigurationService';
+import { VSCodeWorkspaceService } from '../VSCodeWorkspace/VSCodeWorkspaceService';
 
 export class ErrorHandlingService {
 
@@ -129,6 +132,41 @@ ${stackTrace}
             }
 
         });
+    }
+
+    static createGenerateRecipeErrorCaptureFile(customGenerateRecipeError: Error, executedCommand: string) {
+        
+        // ensure dedicated directory for generated recipes exists
+        const workspaceRoot = VSCodeWorkspaceService.getWorkspaceRoot();
+        const generatedRecipesFolderName = ConfigurationService.getGeneratedRecipesDefaultFolderName();
+
+        const errorsGenerationFolderName = this.getRecipeGenerationErrorsFolderName();
+        const expectedErrorsFolderPath = `${workspaceRoot}/treecipe/${generatedRecipesFolderName}/${errorsGenerationFolderName}`;
+        if (!fs.existsSync(expectedErrorsFolderPath)) {
+            fs.mkdirSync(expectedErrorsFolderPath, { recursive: true });
+        }
+        
+        const isoDateTimestamp = VSCodeWorkspaceService.getNowIsoDateTimestamp();
+        
+        let recipeErrorGenerationFileName = 'generateRecipeError_' + isoDateTimestamp + '.json';
+
+        const outputFilePath = `${expectedErrorsFolderPath}/${recipeErrorGenerationFileName}`;
+        
+        const jsonErrorDetail = JSON.stringify(customGenerateRecipeError, null, 2);
+        
+        fs.writeFile(outputFilePath, jsonErrorDetail, (error) => {
+            if (error) {
+                throw new Error(`an error occurred when creating file to capture xml parsing error for ${customGenerateRecipeError.message}.`);
+            } 
+        });
+
+        vscode.window.showWarningMessage('XMLFileProcessor error captured in file: ' + recipeErrorGenerationFileName, );
+        VSCodeWorkspaceService.openFileInEditor(outputFilePath);
+    
+    }
+
+    static getRecipeGenerationErrorsFolderName() {
+        return 'RecipeGenerationErrors';
     }
 
 }

--- a/src/treecipe/src/ErrorHandlingService/ErrorHandlingService.ts
+++ b/src/treecipe/src/ErrorHandlingService/ErrorHandlingService.ts
@@ -165,6 +165,37 @@ ${stackTrace}
     
     }
 
+    static createGetRecipeFakerErrorCaptureFile(customGenerateFakerJSValueError: Error, executedCommand: string) {
+    
+        // ensure dedicated directory for generated recipes exists
+        const workspaceRoot = VSCodeWorkspaceService.getWorkspaceRoot();
+        const generatedRecipesFolderName = ConfigurationService.getGeneratedRecipesDefaultFolderName();
+
+        const errorsGenerationFolderName = this.getRecipeGenerationErrorsFolderName();
+        const expectedErrorsFolderPath = `${workspaceRoot}/treecipe/${generatedRecipesFolderName}/${errorsGenerationFolderName}`;
+        if (!fs.existsSync(expectedErrorsFolderPath)) {
+            fs.mkdirSync(expectedErrorsFolderPath, { recursive: true });
+        }
+    
+        const isoDateTimestamp = VSCodeWorkspaceService.getNowIsoDateTimestamp();
+        
+        let recipeErrorGenerationFileName = 'getFakerJSValueError' + isoDateTimestamp + '.json';
+
+        const outputFilePath = `${expectedErrorsFolderPath}/${recipeErrorGenerationFileName}`;
+        
+        const jsonErrorDetail = JSON.stringify(customGenerateFakerJSValueError, null, 2);
+        
+        fs.writeFile(outputFilePath, jsonErrorDetail, (error) => {
+            if (error) {
+                throw new Error(`an error occurred when creating file to capture xml parsing error for ${customGenerateFakerJSValueError.message}.`);
+            } 
+        });
+
+        vscode.window.showWarningMessage('XMLFileProcessor error captured in file: ' + recipeErrorGenerationFileName, );
+        VSCodeWorkspaceService.openFileInEditor(outputFilePath);
+
+    }
+
     static getRecipeGenerationErrorsFolderName() {
         return 'RecipeGenerationErrors';
     }

--- a/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
@@ -4,6 +4,7 @@ import * as yaml from 'js-yaml';
 import { faker } from '@faker-js/faker';
 
 import { IFakerRecipeProcessor } from '../IFakerRecipeProcessor';
+import { ErrorHandlingService } from '../../ErrorHandlingService/ErrorHandlingService';
 
 export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
 
@@ -29,9 +30,31 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
                 let fieldApiNameByFakerJSEvaluations: Record<string, string> = {};
                 for (const [fieldName, fieldExpression] of Object.entries(fieldsTemplate)) {
 
-                    fieldApiNameByFakerJSEvaluations[fieldName] = await this.evaluateFakerJSExpression(fieldExpression, 
-                                                                                                        fieldApiNameByFakerJSEvaluations, 
-                                                                                                        fieldName);
+                    try {
+
+                        fieldApiNameByFakerJSEvaluations[fieldName] = await this.evaluateFakerJSExpression(fieldExpression, 
+                                                                                                            fieldApiNameByFakerJSEvaluations, 
+                                                                                                            fieldName);
+
+                    } catch (error) {
+                        
+                        const executedCommand = "FakerJSRecipeProcessor.generateFakeDataBySelectedRecipeFile";
+                        const customErrorMessage = `Error evaluating faker-js expression syntax: [[ ${fieldName} - ${ fieldExpression } ]] - ${error.message}`;
+                        
+                        const customFakerJSEvaluationError = new Error();
+                        customFakerJSEvaluationError.message = customErrorMessage;
+                
+                        customFakerJSEvaluationError.name = "GenerateFakerJSValueError";
+                        customFakerJSEvaluationError.stack = error.stack;
+                
+                        customFakerJSEvaluationError.cause = fieldExpression;
+                
+                        ErrorHandlingService.createFakerExpressionEvaluationErrorCaptureFile(customFakerJSEvaluationError, executedCommand);
+                        
+                        throw customFakerJSEvaluationError;
+                                    
+                    }
+                   
                 }
     
                 generatedData.push({
@@ -40,6 +63,7 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
                     nickname: nickname,
                     fields: fieldApiNameByFakerJSEvaluations,
                 });
+                
             }
 
         };

--- a/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
@@ -39,15 +39,15 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
                     } catch (error) {
                         
                         const executedCommand = "FakerJSRecipeProcessor.generateFakeDataBySelectedRecipeFile";
-                        const customErrorMessage = `Error evaluating faker-js expression syntax: [[ ${fieldName} - ${ fieldExpression } ]] - ${error.message}`;
+                        const customErrorMessage = `Error evaluating faker-js expression syntax << ${fieldName} - ${ fieldExpression } >> - ${error.message}`;
                         
                         const customFakerJSEvaluationError = new Error();
                         customFakerJSEvaluationError.message = customErrorMessage;
                 
-                        customFakerJSEvaluationError.name = "GenerateFakerJSValueError";
+                        customFakerJSEvaluationError.name = "FakerJSExpressionEvaluationError";
                         customFakerJSEvaluationError.stack = error.stack;
                 
-                        customFakerJSEvaluationError.cause = fieldExpression;
+                        customFakerJSEvaluationError.cause = error.message;
                 
                         ErrorHandlingService.createFakerExpressionEvaluationErrorCaptureFile(customFakerJSEvaluationError, executedCommand);
                         
@@ -63,7 +63,7 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
                     nickname: nickname,
                     fields: fieldApiNameByFakerJSEvaluations,
                 });
-                
+
             }
 
         };

--- a/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
@@ -292,11 +292,7 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
             matchingCustomFunctionRegex
         } = this.getExpectedDateRegExPatterns();
 
-        // const isCustomDateFunction = (originalCode: string) => matchingCustomFunctionRegex.test(originalCode);
         let modifiedCode = originalCode;
-        // if ( isCustomDateFunction ) {
-        //     modifiedCode = modifiedCode.replaceAll(" ", ""); // Remove all whitespace to avoid any scenarios where expected regex matches wouldn't work
-        // }
 
         // Replace date_between
         modifiedCode = modifiedCode.replace(dateBetweenRegex, (match, fromValue, toValue) => {

--- a/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts
@@ -86,16 +86,6 @@ describe('Shared FakerJSRecipeProcessor tests', () => {
               
           const transformed: Map<string, CollectionsApiJsonStructure>  = fakerJSRecipeProcessor.transformFakerJsonDataToCollectionApiFormattedFilesBySObject(result);
 
-          // transformed.forEach((collectionsApiContent, sobjectApiName) => {
-
-          //     CollectionsApiService.createCollectionsApiFile(
-          //         sobjectApiName, 
-          //         collectionsApiContent, 
-          //         'fullPathToStoreDatasetFiles'
-          //     );
-              
-          // });
-
           expect(fs.readFileSync).toHaveBeenCalledWith(fakeTestFile, 'utf8');
 
           // below expect assert will not work without spy
@@ -104,10 +94,7 @@ describe('Shared FakerJSRecipeProcessor tests', () => {
           const parsedResult = JSON.parse(result);
 
           expect(parsedResult.length).toBe(2);
-          // expect(parsedResult[0].object).toBe('Account');
-          // expect(parsedResult[0].nickname).toBe('standard_account');
-          // expect(parsedResult[0].fields.Name).toBe('Acme Corp');
-          // expect(parsedResult[0].fields.Description).toBe('Innovative solutions');
+         
 
       });
 

--- a/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/SnowfakeryRecipeProcessor.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/SnowfakeryRecipeProcessor.ts
@@ -2,10 +2,9 @@ import { exec } from 'child_process';
 import * as vscode from 'vscode';
 
 import { IFakerRecipeProcessor } from '../IFakerRecipeProcessor';
+import { ErrorHandlingService } from '../../ErrorHandlingService/ErrorHandlingService';
 
 export class SnowfakeryRecipeProcessor implements IFakerRecipeProcessor {
-
-    private baseSnowfakeryInstallationErrorMessage:string  = 'An error occurred in checking for snowfakery installation';
 
     async isRecipeProcessorSetup(): Promise<boolean> {
 
@@ -15,7 +14,7 @@ export class SnowfakeryRecipeProcessor implements IFakerRecipeProcessor {
             const handleSnowfakeryVersionCheckCallback = (cliCommandError, cliCommandStandardOut) => {
 
                 if (cliCommandError) {
-                    reject(new Error(`${this.baseSnowfakeryInstallationErrorMessage}: ${cliCommandError.message}`));
+                    reject(new Error(`An error occurred in checking for snowfakery installation: ${cliCommandError.message}`));
                 } else {
 
                     /*
@@ -45,8 +44,18 @@ export class SnowfakeryRecipeProcessor implements IFakerRecipeProcessor {
 
                 if (cliCommandError) {
                     
-                    const snowfakeryError = new Error(`${this.baseSnowfakeryInstallationErrorMessage}: ${cliCommandError.message}`);
-                    reject(snowfakeryError);
+                    const executedCommand = "SnowfakeryRecipeProcessor.generateFakeDataBySelectedRecipeFile";
+                    
+                    const customFakerEvaluationError = new Error();
+                    customFakerEvaluationError.message = cliCommandError.message;
+            
+                    customFakerEvaluationError.name = "SnowfakeryEvaluationError";
+                    customFakerEvaluationError.stack = cliCommandError.stack;
+            
+                    customFakerEvaluationError.cause = cliCommandError.message;
+            
+                    ErrorHandlingService.createFakerExpressionEvaluationErrorCaptureFile(customFakerEvaluationError, executedCommand);
+                    reject(customFakerEvaluationError);
 
                 } else {
 

--- a/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/tests/SnowfakeryRecipeProcessor.test.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/tests/SnowfakeryRecipeProcessor.test.ts
@@ -8,7 +8,6 @@ jest.mock('child_process', () => ({
     exec: jest.fn()
 }));
 
-// import * as vscode from 'vscode';
 import * as fs from 'fs';
 
 import { VSCodeWorkspaceService } from '../../../VSCodeWorkspace/VSCodeWorkspaceService';
@@ -22,7 +21,7 @@ jest.mock('vscode', () => ({
       workspaceFolders: jest.fn()
     }
   
-  }), { virtual: true });
+}), { virtual: true });
 
 
 describe('Shared SnowfakeryRecipeProcessor tests', () => {

--- a/src/treecipe/src/ObjectInfoWrapper/FieldInfo.ts
+++ b/src/treecipe/src/ObjectInfoWrapper/FieldInfo.ts
@@ -52,9 +52,10 @@ export class FieldInfo {
 }
 
 export interface IPicklistValue {
-  fullName: string;
+  picklistOptionApiName: string;
   label: string;
   default?: boolean;
-  availableForControllingValues?: string[];
+  controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection?: string[];
+  isActive?: boolean;
 }
 

--- a/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts
+++ b/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts
@@ -243,10 +243,10 @@ ${this.generateTabs(5)}${randomChoicesBreakdown}`;
     getMapSalesforceFieldToFakerValue():Record<string, string> {
 
         const salesforceFieldToNPMFakerMap: Record<string, string> = {
-            'text': `\${{ faker.lorem.text(50) }}`,
+            'text': `\${{ faker.lorem.text(5).substring(0, 255) }}`,
             'textarea': `\${{ faker.lorem.paragraph() }}`,
-            'longtextarea': `\${{ faker.lorem.text(1000) }}`,
-            'html': `\${{ faker.lorem.text(1000) }}`,
+            'longtextarea': `\${{ faker.lorem.text(100) }}`,
+            'html': `\${{ faker.string.alpha(10) }}`,
             'email': `\${{ faker.internet.email() }}`,
             'phone': `|
                 \${{ faker.phone.number({style:'national'}) }}`,

--- a/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts
+++ b/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts
@@ -486,4 +486,19 @@ ${this.generateTabs(5)}${randomChoicesBreakdown}`;
     
     }
 
+    getStandardAndGlobalValueSetTODOPlaceholderWithExample():string {
+
+        const emptyPicklistXMLDetailRecipePlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS PICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPALCE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ faker.helpers.arrayElement(['banana', 'orange', 'apple']) }}`;
+        return emptyPicklistXMLDetailRecipePlaceholder;
+
+    }
+
+    getMultipicklistTODOPlaceholderWithExample():string {
+
+        const emptyMultiSelectXMLDetailPlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS MULTIPICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPLACE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ (faker.helpers.arrayElements(['apple', 'orange', 'banana']) ).join(';') }}`;
+        return emptyMultiSelectXMLDetailPlaceholder;    
+
+
+    }
+
 }

--- a/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/tests/FakerJSRecipeFakerService.test.ts
+++ b/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/tests/FakerJSRecipeFakerService.test.ts
@@ -13,7 +13,7 @@ describe('FakerJSRecipeFakerService Shared Intstance Tests', () => {
         const seeOnePagerPlaceholder = '### TODO -- SEE ONE PAGER - https://gist.github.com/jdschleicher/4abfd188a933598833285ee76e560445';
 
         test('Text field returns correct npm faker expression', () => {
-            expect(fieldTypeToNPMFakerMappings['text']).toBe('${{ faker.lorem.text(50) }}');
+            expect(fieldTypeToNPMFakerMappings['text']).toBe('${{ faker.lorem.text(5).substring(0, 255) }}');
         });
 
         test('TextArea field returns correct npm faker expression', () => {
@@ -25,11 +25,11 @@ describe('FakerJSRecipeFakerService Shared Intstance Tests', () => {
 
         test('LongTextArea field returns correct npm faker expression', () => {
             const longTextAreaExpression = fieldTypeToNPMFakerMappings['longtextarea'];
-            expect(longTextAreaExpression).toBe('${{ faker.lorem.text(1000) }}');
+            expect(longTextAreaExpression).toBe('${{ faker.lorem.text(100) }}');
         });
 
         test('RichTextArea Html field returns correct npm faker expression', () => {
-            expect(fieldTypeToNPMFakerMappings['html']).toBe('${{ faker.lorem.text(1000) }}');
+            expect(fieldTypeToNPMFakerMappings['html']).toBe('${{ faker.string.alpha(10) }}');
         });
 
         test('Email field returns correct npm faker expression', () => {

--- a/src/treecipe/src/RecipeFakerService.ts/IRecipeFakerService.ts
+++ b/src/treecipe/src/RecipeFakerService.ts/IRecipeFakerService.ts
@@ -26,4 +26,6 @@ export interface IRecipeFakerService {
         dependentFieldApiName: string,
         controllingFieldApiName: string,
         controllingValue: string): string
+    getMultipicklistTODOPlaceholderWithExample(): string
+    getStandardAndGlobalValueSetTODOPlaceholderWithExample(): string
 }

--- a/src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts
+++ b/src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts
@@ -379,4 +379,18 @@ ${this.generateTabs(5)}${randomChoicesBreakdown}`;
 
     }
 
+     getStandardAndGlobalValueSetTODOPlaceholderWithExample():string {
+
+        const emptyPicklistXMLDetailRecipePlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS PICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPALCE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ random_choice('apple', 'orange', 'banana') }}`;
+        return emptyPicklistXMLDetailRecipePlaceholder;
+
+    }
+
+    getMultipicklistTODOPlaceholderWithExample():string {
+
+        const emptyMultiSelectXMLDetailPlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS MULTIPICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPLACE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ (';').join((fake.random_sample(elements=('apple', 'orange', 'banana')))) }}`;
+        return emptyMultiSelectXMLDetailPlaceholder;
+        
+    }
+
 }

--- a/src/treecipe/src/RecipeService/RecipeService.ts
+++ b/src/treecipe/src/RecipeService/RecipeService.ts
@@ -62,7 +62,7 @@ export class RecipeService {
                             const emptyPicklistXMLDetailRecipePlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS PICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPALCE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ random_choice('apple', 'orange', 'banana') }}`;
                             return emptyPicklistXMLDetailRecipePlaceholder;
                         }
-                        const availablePicklistChoices = xmlFieldDetail.picklistValues.map(detail => detail.fullName);
+                        const availablePicklistChoices = xmlFieldDetail.picklistValues.map(picklistOption => picklistOption.picklistOptionApiName);
                         fakeRecipeValue = this.fakerService.buildPicklistRecipeValueByXMLFieldDetail(availablePicklistChoices, 
                                                                                                     recordTypeApiToRecordTypeWrapperMap,
                                                                                                     xmlFieldDetail.apiName);  
@@ -77,7 +77,7 @@ export class RecipeService {
                         const emptyMultiSelectXMLDetailPlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS MULTIPICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPLACE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ (';').join((fake.random_sample(elements=('apple', 'orange', 'banana')))) }}`;
                         return emptyMultiSelectXMLDetailPlaceholder;
                     }
-                    const availablePicklistChoices = xmlFieldDetail.picklistValues.map(detail => detail.fullName);
+                    const availablePicklistChoices = xmlFieldDetail.picklistValues.map(picklistOption => picklistOption.picklistOptionApiName);
                     fakeRecipeValue = this.fakerService.buildMultiSelectPicklistRecipeValueByXMLFieldDetail(availablePicklistChoices, 
                                                                                                             recordTypeApiToRecordTypeWrapperMap,
                                                                                                             xmlFieldDetail.apiName
@@ -149,13 +149,13 @@ export class RecipeService {
         }
         xmlFieldDetail.picklistValues.forEach(picklistOption => {
             
-            if ( !(picklistOption.availableForControllingValues) ) {
+            if ( !(picklistOption.controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection) ) {
                 return '';
             }
-            picklistOption.availableForControllingValues.forEach((controllingValue) => {
+            picklistOption.controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection.forEach((controllingValue) => {
 
                 if ( controllingValue in controllingValueToPicklistOptions ) {
-                    controllingValueToPicklistOptions[controllingValue].push(picklistOption.fullName);
+                    controllingValueToPicklistOptions[controllingValue].push(picklistOption.picklistOptionApiName);
                 } else {
                     controllingValueToPicklistOptions[controllingValue] = [ picklistOption.fullName ];
                 }

--- a/src/treecipe/src/RecipeService/RecipeService.ts
+++ b/src/treecipe/src/RecipeService/RecipeService.ts
@@ -59,7 +59,7 @@ export class RecipeService {
     
                         if ( !(xmlFieldDetail.picklistValues) ) {
                             // THIS SCENARIO INDICATEDS THAT THE PICKLIST FIELD UTILIZED A GLOBAL VALUE SET
-                            const emptyPicklistXMLDetailRecipePlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS PICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPALCE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ random_choice('apple', 'orange', 'banana') }}`;
+                            const emptyPicklistXMLDetailRecipePlaceholder = this.fakerService.getStandardAndGlobalValueSetTODOPlaceholderWithExample();
                             return emptyPicklistXMLDetailRecipePlaceholder;
                         }
                         const availablePicklistChoices = xmlFieldDetail.picklistValues.map(picklistOption => picklistOption.picklistOptionApiName);
@@ -74,7 +74,7 @@ export class RecipeService {
     
                     if ( !(xmlFieldDetail.picklistValues) ) {
                         // THIS SCENARIO INDICATEDS THAT THE PICKLIST FIELD UTILIZED A GLOBAL VALUE SET
-                        const emptyMultiSelectXMLDetailPlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS MULTIPICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPLACE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ (';').join((fake.random_sample(elements=('apple', 'orange', 'banana')))) }}`;
+                        const emptyMultiSelectXMLDetailPlaceholder = this.fakerService.getMultipicklistTODOPlaceholderWithExample();
                         return emptyMultiSelectXMLDetailPlaceholder;
                     }
                     const availablePicklistChoices = xmlFieldDetail.picklistValues.map(picklistOption => picklistOption.picklistOptionApiName);

--- a/src/treecipe/src/RecipeService/RecipeService.ts
+++ b/src/treecipe/src/RecipeService/RecipeService.ts
@@ -1,3 +1,4 @@
+import { ErrorHandlingService } from "../ErrorHandlingService/ErrorHandlingService";
 import { IRecipeFakerService } from "../RecipeFakerService.ts/IRecipeFakerService";
 import { RecordTypeWrapper } from "../RecordTypeService/RecordTypesWrapper";
 import { XMLFieldDetail } from "../XMLProcessingService/XMLFieldDetail";
@@ -44,59 +45,82 @@ export class RecipeService {
         
         let fakeRecipeValue;
         const fieldType = xmlFieldDetail.fieldType.toLowerCase();
-        switch (fieldType) {
-            
-            case 'picklist':
-                
-                if (xmlFieldDetail.controllingField) {
-                    // THIS SCENARIO INDICATES THAT THE PICKLIST FIELD IS DEPENDENT
-                    fakeRecipeValue = this.getDependentPicklistRecipeFakerValue(xmlFieldDetail, recordTypeApiToRecordTypeWrapperMap);
-                } else {
 
+        try {
+            
+            switch (fieldType) {
+            
+                case 'picklist':
+                    
+                    if (xmlFieldDetail.controllingField) {
+                        // THIS SCENARIO INDICATES THAT THE PICKLIST FIELD IS DEPENDENT
+                        fakeRecipeValue = this.getDependentPicklistRecipeFakerValue(xmlFieldDetail, recordTypeApiToRecordTypeWrapperMap);
+                    } else {
+    
+                        if ( !(xmlFieldDetail.picklistValues) ) {
+                            // THIS SCENARIO INDICATEDS THAT THE PICKLIST FIELD UTILIZED A GLOBAL VALUE SET
+                            const emptyPicklistXMLDetailRecipePlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS PICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPALCE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ random_choice('apple', 'orange', 'banana') }}`;
+                            return emptyPicklistXMLDetailRecipePlaceholder;
+                        }
+                        const availablePicklistChoices = xmlFieldDetail.picklistValues.map(detail => detail.fullName);
+                        fakeRecipeValue = this.fakerService.buildPicklistRecipeValueByXMLFieldDetail(availablePicklistChoices, 
+                                                                                                    recordTypeApiToRecordTypeWrapperMap,
+                                                                                                    xmlFieldDetail.apiName);  
+                    }
+    
+                    return fakeRecipeValue;
+                    
+                case 'multiselectpicklist':
+    
                     if ( !(xmlFieldDetail.picklistValues) ) {
                         // THIS SCENARIO INDICATEDS THAT THE PICKLIST FIELD UTILIZED A GLOBAL VALUE SET
-                        const emptyPicklistXMLDetailRecipePlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS PICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPALCE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ random_choice('apple', 'orange', 'banana') }}`;
-                        return emptyPicklistXMLDetailRecipePlaceholder;
+                        const emptyMultiSelectXMLDetailPlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS MULTIPICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPLACE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ (';').join((fake.random_sample(elements=('apple', 'orange', 'banana')))) }}`;
+                        return emptyMultiSelectXMLDetailPlaceholder;
                     }
                     const availablePicklistChoices = xmlFieldDetail.picklistValues.map(detail => detail.fullName);
-                    fakeRecipeValue = this.fakerService.buildPicklistRecipeValueByXMLFieldDetail(availablePicklistChoices, 
-                                                                                                recordTypeApiToRecordTypeWrapperMap,
-                                                                                                xmlFieldDetail.apiName);  
-                }
+                    fakeRecipeValue = this.fakerService.buildMultiSelectPicklistRecipeValueByXMLFieldDetail(availablePicklistChoices, 
+                                                                                                            recordTypeApiToRecordTypeWrapperMap,
+                                                                                                            xmlFieldDetail.apiName
+                                                                                                        );
+            
+                    return fakeRecipeValue;
+                    
+                // case 'masterdetail':
+                    
+                //     return {
+                //         type: 'lookup'
+                //     };
+    
+                // case 'lookup':
+    
+                //     return 'test';
+                    
+                default: 
+    
+                    fakeRecipeValue = this.getFakeValueIfExpectedSalesforceFieldType(fieldType);
+                    return fakeRecipeValue;
+    
+            }
 
-                return fakeRecipeValue;
-                
-            case 'multiselectpicklist':
-
-                if ( !(xmlFieldDetail.picklistValues) ) {
-                    // THIS SCENARIO INDICATEDS THAT THE PICKLIST FIELD UTILIZED A GLOBAL VALUE SET
-                    const emptyMultiSelectXMLDetailPlaceholder = `### TODO: POSSIBLE GLOBAL OR STANDARD VALUE SET USED FOR THIS MULTIPICKLIST AS DETAILS ARE NOT IN FIELD XML MARKUP -- FIND ASSOCIATED VALUE SET AND REPLACE COMMA SEPARATED FRUITS WITH VALUE SET OPTIONS: \${{ (';').join((fake.random_sample(elements=('apple', 'orange', 'banana')))) }}`;
-                    return emptyMultiSelectXMLDetailPlaceholder;
-                }
-                const availablePicklistChoices = xmlFieldDetail.picklistValues.map(detail => detail.fullName);
-                fakeRecipeValue = this.fakerService.buildMultiSelectPicklistRecipeValueByXMLFieldDetail(availablePicklistChoices, 
-                                                                                                        recordTypeApiToRecordTypeWrapperMap,
-                                                                                                        xmlFieldDetail.apiName
-                                                                                                    );
-        
-                return fakeRecipeValue;
-                
-            // case 'masterdetail':
-                
-            //     return {
-            //         type: 'lookup'
-            //     };
-
-            // case 'lookup':
-
-            //     return 'test';
-                
-            default: 
-
-                fakeRecipeValue = this.getFakeValueIfExpectedSalesforceFieldType(fieldType);
-                return fakeRecipeValue;
+        } catch (error) {
+            
+            const executedCommand = "XMLFileProcessor.getRecipeFakeValueByXMLFieldDetail";
+            const customErrorMessage = `Error generating fake value: ${xmlFieldDetail.apiName} - ${error.message}`;
+            
+            const customGenerateFakerJSValueError = new Error();
+            customGenerateFakerJSValueError.message = customErrorMessage;
+    
+            customGenerateFakerJSValueError.name = "GenerateFakerJSValueError";
+            customGenerateFakerJSValueError.stack = error.stack;
+    
+            customGenerateFakerJSValueError.cause = xmlFieldDetail;
+    
+            ErrorHandlingService.createGetRecipeFakerErrorCaptureFile(customGenerateFakerJSValueError, executedCommand);
+            
+            throw customGenerateFakerJSValueError;
 
         }
+    
 
     }
     

--- a/src/treecipe/src/RecipeService/RecipeService.ts
+++ b/src/treecipe/src/RecipeService/RecipeService.ts
@@ -157,7 +157,7 @@ export class RecipeService {
                 if ( controllingValue in controllingValueToPicklistOptions ) {
                     controllingValueToPicklistOptions[controllingValue].push(picklistOption.picklistOptionApiName);
                 } else {
-                    controllingValueToPicklistOptions[controllingValue] = [ picklistOption.fullName ];
+                    controllingValueToPicklistOptions[controllingValue] = [ picklistOption.picklistOptionApiName ];
                 }
 
             });

--- a/src/treecipe/src/RecipeService/tests/RecipeService.test.ts
+++ b/src/treecipe/src/RecipeService/tests/RecipeService.test.ts
@@ -260,34 +260,34 @@ describe('SnowfakeryRecipeService IRecipeService Implementation Shared Intstance
         
             const expectedPicklistFieldDetails:IPicklistValue[] = [
                 {
-                    fullName: 'tree',
+                    picklistOptionApiName: 'tree',
                     label: 'tree',
                     default: false,
-                    availableForControllingValues: ['cle', 'eastlake', 'madison', 'willoughby']
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'willoughby']
                 },
                 {
-                    fullName: 'weed',
+                    picklistOptionApiName: 'weed',
                     label: 'weed',
                     default: false,
-                    availableForControllingValues: ['cle', 'eastlake', 'madison', 'mentor', 'wickliffe', 'willoughby']
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'mentor', 'wickliffe', 'willoughby']
                 },
                 {
-                    fullName: 'mulch',
+                    picklistOptionApiName: 'mulch',
                     label: 'mulch',
                     default: false,
-                    availableForControllingValues: ['cle', 'eastlake', 'willoughby']
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'willoughby']
                 },
                 {
-                    fullName: 'rocks',
+                    picklistOptionApiName: 'rocks',
                     label: 'rocks',
                     default: false,
-                    availableForControllingValues: ['cle', 'wickliffe']
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'wickliffe']
                 },
                 {
-                    fullName: 'plant',
+                    picklistOptionApiName: 'plant',
                     label: 'plant',
                     default: false,
-                    availableForControllingValues: ['madison', 'mentor']
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['madison', 'mentor']
                 }
                
             ];
@@ -317,31 +317,31 @@ describe('SnowfakeryRecipeService IRecipeService Implementation Shared Intstance
 
             const expectedPicklistFieldDetails:IPicklistValue[] = [
                 {
-                    fullName: 'tree',
+                    picklistOptionApiName: 'tree',
                     label: 'tree',
                     default: false
                 },
                 {
-                    fullName: 'weed',
+                    picklistOptionApiName: 'weed',
                     label: 'weed',
                     default: false,
-                    availableForControllingValues: []
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: []
                 },
                 {
-                    fullName: 'mulch',
+                    picklistOptionApiName: 'mulch',
                     label: 'mulch',
                     default: false,
                 },
                 {
-                    fullName: 'rocks',
+                    picklistOptionApiName: 'rocks',
                     label: 'rocks',
                     default: false                
                 },
                 {
-                    fullName: 'plant',
+                    picklistOptionApiName: 'plant',
                     label: 'plant',
                     default: false,
-                    availableForControllingValues: []
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: []
                 }
                
             ];
@@ -435,7 +435,6 @@ describe('FakerJSRecipeService IRecipeService Implementation Shared Intstance Te
         test('given expected datetime XMLFieldDetail, returns the expected fakerJS YAML recipe value', () => {
 
             const expectedDatetimeXMLFieldDetail:XMLFieldDetail = XMLMarkupMockService.getDateTimeFieldDetail();
-            // const expectedDatetimeSnowfakeryValue = '${{ (fake.date_time_between(start_date="-1y", end_date="now")).strftime("%Y-%m-%dT%H:%M:%S.000+0000") }}';
             const expectedDatetimeFakerJSExpression = `|
                 \${{ faker.date.between({ from: new Date('2023-01-01T00:00:00Z'), to: new Date() }).toISOString() }}`;
             const recordTypeNameByRecordTypeNameToXMLMarkup = {};
@@ -629,34 +628,34 @@ describe('FakerJSRecipeService IRecipeService Implementation Shared Intstance Te
         
             const expectedPicklistFieldDetails:IPicklistValue[] = [
                 {
-                    fullName: 'tree',
+                    picklistOptionApiName: 'tree',
                     label: 'tree',
                     default: false,
-                    availableForControllingValues: ['cle', 'eastlake', 'madison', 'willoughby']
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'willoughby']
                 },
                 {
-                    fullName: 'weed',
+                    picklistOptionApiName: 'weed',
                     label: 'weed',
                     default: false,
-                    availableForControllingValues: ['cle', 'eastlake', 'madison', 'mentor', 'wickliffe', 'willoughby']
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'mentor', 'wickliffe', 'willoughby']
                 },
                 {
-                    fullName: 'mulch',
+                    picklistOptionApiName: 'mulch',
                     label: 'mulch',
                     default: false,
-                    availableForControllingValues: ['cle', 'eastlake', 'willoughby']
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'willoughby']
                 },
                 {
-                    fullName: 'rocks',
+                    picklistOptionApiName: 'rocks',
                     label: 'rocks',
                     default: false,
-                    availableForControllingValues: ['cle', 'wickliffe']
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'wickliffe']
                 },
                 {
-                    fullName: 'plant',
+                    picklistOptionApiName: 'plant',
                     label: 'plant',
                     default: false,
-                    availableForControllingValues: ['madison', 'mentor']
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['madison', 'mentor']
                 }
                
             ];
@@ -686,31 +685,31 @@ describe('FakerJSRecipeService IRecipeService Implementation Shared Intstance Te
 
             const expectedPicklistFieldDetails:IPicklistValue[] = [
                 {
-                    fullName: 'tree',
+                    picklistOptionApiName: 'tree',
                     label: 'tree',
                     default: false
                 },
                 {
-                    fullName: 'weed',
+                    picklistOptionApiName: 'weed',
                     label: 'weed',
                     default: false,
-                    availableForControllingValues: []
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: []
                 },
                 {
-                    fullName: 'mulch',
+                    picklistOptionApiName: 'mulch',
                     label: 'mulch',
                     default: false,
                 },
                 {
-                    fullName: 'rocks',
+                    picklistOptionApiName: 'rocks',
                     label: 'rocks',
                     default: false                
                 },
                 {
-                    fullName: 'plant',
+                    picklistOptionApiName: 'plant',
                     label: 'plant',
                     default: false,
-                    availableForControllingValues: []
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: []
                 }
                
             ];
@@ -736,6 +735,65 @@ describe('FakerJSRecipeService IRecipeService Implementation Shared Intstance Te
             expect(actualFakerValue).toBe(expectedDependentPicklistRecipeValue);
 
         });
+
+        test('given expected XMLDetail with isActive options set to false and active, expected controllingvalue to options are built and correct snowfakery fake value is returned', () => {
+        
+            const expectedPicklistFieldDetails:IPicklistValue[] = [
+                {
+                    picklistOptionApiName: 'tree',
+                    label: 'tree',
+                    default: false,
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'willoughby']
+                },
+                {
+                    picklistOptionApiName: 'weed',
+                    label: 'weed',
+                    default: false,
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'mentor', 'wickliffe', 'willoughby']
+                },
+                {
+                    picklistOptionApiName: 'mulch',
+                    label: 'mulch',
+                    default: false,
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'willoughby']
+                },
+                {
+                    picklistOptionApiName: 'rocks',
+                    label: 'rocks',
+                    default: false,
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'wickliffe']
+                },
+                {
+                    picklistOptionApiName: 'plant',
+                    label: 'plant',
+                    default: false,
+                    controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['madison', 'mentor']
+                }
+               
+            ];
+         
+            const expectedXMLFieldDetail:XMLFieldDetail = {
+                fieldType : "picklist",
+                apiName : "DependentPicklist__c",
+                picklistValues : expectedPicklistFieldDetails,
+                referenceTo : "",
+                fieldLabel : "Dependent Picklist",
+                controllingField : "Picklist__c",
+                xmlMarkup: XMLMarkupMockService.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup()
+            };
+ 
+            const recordTypeNameByRecordTypeNameToXMLMarkup = {};
+            const expectedDependentListFakeValue = RecipeMockService.getMockFakerJSDependentPicklistRecipeValueWithoutRecordTypeDetail();
+            const actualRecipeValue = recipeServiceWithFakerJS.getDependentPicklistRecipeFakerValue(
+                expectedXMLFieldDetail, 
+                recordTypeNameByRecordTypeNameToXMLMarkup
+            );
+
+            expect(actualRecipeValue).toBe(expectedDependentListFakeValue);
+
+        });
+
+
 
     });
 

--- a/src/treecipe/src/RecipeService/tests/RecipeService.test.ts
+++ b/src/treecipe/src/RecipeService/tests/RecipeService.test.ts
@@ -36,7 +36,8 @@ describe('SnowfakeryRecipeService IRecipeService Implementation Shared Intstance
             let fakeXMLFieldDetail: XMLFieldDetail = {
                 fieldType: fakeFieldTypeValue,
                 apiName: "Fake__c",
-                fieldLabel: "Fake"
+                fieldLabel: "Fake",
+                xmlMarkup: 'not a real xml markup'
             };
             const expectedRecipeValue = `"FieldType Not Handled -- ${fakeFieldTypeValue} does not exist in this programs Salesforce field map."`;
             const recordTypeNameToRecordTypeXMLMarkup = {};
@@ -297,7 +298,8 @@ describe('SnowfakeryRecipeService IRecipeService Implementation Shared Intstance
                 picklistValues : expectedPicklistFieldDetails,
                 referenceTo : "",
                 fieldLabel : "Dependent Picklist",
-                controllingField : "Picklist__c"
+                controllingField : "Picklist__c",
+                xmlMarkup: XMLMarkupMockService.getDependentPicklistFieldTypeXMLMarkup()
             };
  
             const recordTypeNameByRecordTypeNameToXMLMarkup = {};
@@ -350,7 +352,8 @@ describe('SnowfakeryRecipeService IRecipeService Implementation Shared Intstance
                 picklistValues : expectedPicklistFieldDetails,
                 referenceTo : "",
                 fieldLabel : "Dependent Picklist",
-                controllingField : "Picklist__c"
+                controllingField : "Picklist__c",
+                xmlMarkup : XMLMarkupMockService.getDependentPicklistFieldTypeXMLMarkup()
             };
 
             const expectedDependentPicklistRecipeValue = recipeServiceWithSnow.getNoValueSettingsToDoRecipeValue(expectedXMLFieldDetail);
@@ -398,7 +401,8 @@ describe('FakerJSRecipeService IRecipeService Implementation Shared Intstance Te
             let fakeXMLFieldDetail: XMLFieldDetail = {
                 fieldType: fakeFieldTypeValue,
                 apiName: "Fake__c",
-                fieldLabel: "Fake"
+                fieldLabel: "Fake",
+                xmlMarkup: "<xml></xml>"
             };
             const expectedRecipeValue = `"FieldType Not Handled -- ${fakeFieldTypeValue} does not exist in this programs Salesforce field map."`;
             const recordTypeNameToRecordTypeXMLMarkup = {};
@@ -663,7 +667,8 @@ describe('FakerJSRecipeService IRecipeService Implementation Shared Intstance Te
                 picklistValues : expectedPicklistFieldDetails,
                 referenceTo : "",
                 fieldLabel : "Dependent Picklist",
-                controllingField : "Picklist__c"
+                controllingField : "Picklist__c",
+                xmlMarkup: XMLMarkupMockService.getDependentPicklistFieldTypeXMLMarkup()
             };
  
             const recordTypeNameByRecordTypeNameToXMLMarkup = {};
@@ -716,7 +721,8 @@ describe('FakerJSRecipeService IRecipeService Implementation Shared Intstance Te
                 picklistValues : expectedPicklistFieldDetails,
                 referenceTo : "",
                 fieldLabel : "Dependent Picklist",
-                controllingField : "Picklist__c"
+                controllingField : "Picklist__c",
+                xmlMarkup : XMLMarkupMockService.getDependentPicklistFieldTypeXMLMarkup()
             };
 
             const expectedDependentPicklistRecipeValue = recipeServiceWithFakerJS.getNoValueSettingsToDoRecipeValue(expectedXMLFieldDetail);

--- a/src/treecipe/src/RecordTypeService/RecordTypeService.ts
+++ b/src/treecipe/src/RecordTypeService/RecordTypeService.ts
@@ -20,7 +20,7 @@ export class RecordTypeService {
         if ( XmlFileProcessor.isXMLFileType(fileName, directoryItemTypeEnum) ) {
 
           const recordTypeXMLObjectDetail:any = await this.getRecordTypeDetailFromRecordTypeFile(fileName, expectedRecordTypesPath);
-          const recordTypeApiName = recordTypeXMLObjectDetail.picklistOptionApiName[0];
+          const recordTypeApiName = recordTypeXMLObjectDetail.fullName[0];
           const recordTypeWrapper = this.initiateRecordTypeWrapperByXMLDetail(recordTypeXMLObjectDetail, recordTypeApiName);
           recordTypeDeveloperNameToRecordTypeWrapper[recordTypeApiName] = recordTypeWrapper;
 

--- a/src/treecipe/src/RecordTypeService/RecordTypeService.ts
+++ b/src/treecipe/src/RecordTypeService/RecordTypeService.ts
@@ -20,7 +20,7 @@ export class RecordTypeService {
         if ( XmlFileProcessor.isXMLFileType(fileName, directoryItemTypeEnum) ) {
 
           const recordTypeXMLObjectDetail:any = await this.getRecordTypeDetailFromRecordTypeFile(fileName, expectedRecordTypesPath);
-          const recordTypeApiName = recordTypeXMLObjectDetail.fullName[0];
+          const recordTypeApiName = recordTypeXMLObjectDetail.picklistOptionApiName[0];
           const recordTypeWrapper = this.initiateRecordTypeWrapperByXMLDetail(recordTypeXMLObjectDetail, recordTypeApiName);
           recordTypeDeveloperNameToRecordTypeWrapper[recordTypeApiName] = recordTypeWrapper;
 

--- a/src/treecipe/src/RecordTypeService/tests/RecordTypeService.test.ts
+++ b/src/treecipe/src/RecordTypeService/tests/RecordTypeService.test.ts
@@ -49,7 +49,7 @@ describe('RecordTypeService Shared Instance Tests', () => {
     
         });
   
-        test('given mocked record type detail with expected picklist, fullname, and developern name structures, returns expected record type api to record type wrapper map', async () => {
+        test('given mocked record type detail with expected picklist, fullname, and developer name structures, returns expected record type api to record type wrapper map', async () => {
   
             const expectedRecordTypeXMLDetail = MockRecordTypeService.getRecordTypeMockOneRecTypeAsObject();
             jest.spyOn(RecordTypeService, 'getRecordTypeDetailFromRecordTypeFile').mockResolvedValue(expectedRecordTypeXMLDetail.RecordType);

--- a/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts
+++ b/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts
@@ -338,6 +338,12 @@ export class VSCodeWorkspaceService {
           vscode.window.showErrorMessage(`Failed to open file: ${filePath} - ${error}`);
           
         }
-      }
+    }
+
+    static showWarningMessage(message: string) {
+
+        vscode.window.showWarningMessage(message);
+
+    }
     
 }

--- a/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts
+++ b/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts
@@ -324,5 +324,20 @@ export class VSCodeWorkspaceService {
         return fakeDataSetsFolderName;
 
     }
+
+    static async openFileInEditor(filePath: string) {
+
+        try {
+
+          const uri = vscode.Uri.file(filePath);
+          const document = await vscode.workspace.openTextDocument(uri); 
+          await vscode.window.showTextDocument(document);     
+
+        } catch (error) {
+
+          vscode.window.showErrorMessage(`Failed to open file: ${filePath} - ${error}`);
+          
+        }
+      }
     
 }

--- a/src/treecipe/src/XMLProcessingService/XMLFieldDetail.ts
+++ b/src/treecipe/src/XMLProcessingService/XMLFieldDetail.ts
@@ -4,6 +4,7 @@ export class XMLFieldDetail {
     public fieldType: string;
     public apiName: string;
     public picklistValues?: IPicklistValue[];
+    public globalValueSetName?: string;
     public referenceTo?: string;
     public fieldLabel: string;
     public controllingField?: string;

--- a/src/treecipe/src/XMLProcessingService/XMLFieldDetail.ts
+++ b/src/treecipe/src/XMLProcessingService/XMLFieldDetail.ts
@@ -7,4 +7,5 @@ export class XMLFieldDetail {
     public referenceTo?: string;
     public fieldLabel: string;
     public controllingField?: string;
+    public xmlMarkup: string;
 }

--- a/src/treecipe/src/XMLProcessingService/XMLFieldDetail.ts
+++ b/src/treecipe/src/XMLProcessingService/XMLFieldDetail.ts
@@ -9,4 +9,5 @@ export class XMLFieldDetail {
     public fieldLabel: string;
     public controllingField?: string;
     public xmlMarkup: string;
+    public isStandardValueSet?: boolean;
 }

--- a/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
+++ b/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
@@ -90,20 +90,24 @@ export class XmlFileProcessor {
     // NOTE: THE INDEX OF ZERO "[0]" USED IN SEVERAL LOCATIONS IS REQUIRED DUE TO HOW THE XML ARE PARSED AS THERE COULD BE 1 OR MANY OF THE SAME ELEMENT NODE
     let picklistFieldDetails:IPicklistValue[] = [];
   
-    let picklistValues = picklistValueSetMarkup.valueSetDefinition[0].value;
-    picklistValues.forEach(valueSetDefinitionElement => {
+    // IF picklistValueSetMarkup.valueSetDefinition IS undefined THIS IS AN INDICATOR THAT THE PICKLIST IS A GLOBAL PICKLIST
+    if (picklistValueSetMarkup.valueSetDefinition !== undefined) {
       
-      const picklistDetail = this.extractPicklistDetailFromValueSetDefinition(valueSetDefinitionElement);
-      const dependentPicklistConfigurationExists = ( picklistValueSetMarkup?.controllingField.length === 1 );
-      // IF THERE IS A CONTROLLING FIELD THEN WE CAN EXPECT THERE TO BE A DEPENDENT PICKLIST CONFIGURATION
-      if (dependentPicklistConfigurationExists) {
-          const dependentPicklistConfigurationDetail = this.getDependentPicklistConfigurationDetailByPicklistDetail(picklistDetail.picklistOptionApiName, picklistValueSetMarkup);
-          picklistDetail.controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection = dependentPicklistConfigurationDetail;
-      }
-      picklistFieldDetails.push(picklistDetail);
-      
-  
-    });
+      let picklistValues = picklistValueSetMarkup.valueSetDefinition[0].value;
+      picklistValues.forEach(valueSetDefinitionElement => {
+        
+        const picklistDetail = this.extractPicklistDetailFromValueSetDefinition(valueSetDefinitionElement);
+        const dependentPicklistConfigurationExists = ( picklistValueSetMarkup?.controllingField?.length === 1 );
+        // IF THERE IS A CONTROLLING FIELD THEN WE CAN EXPECT THERE TO BE A DEPENDENT PICKLIST CONFIGURATION
+        if (dependentPicklistConfigurationExists) {
+            const dependentPicklistConfigurationDetail = this.getDependentPicklistConfigurationDetailByPicklistDetail(picklistDetail.picklistOptionApiName, picklistValueSetMarkup);
+            picklistDetail.controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection = dependentPicklistConfigurationDetail;
+        }
+        picklistFieldDetails.push(picklistDetail);
+        
+      });
+
+    } 
 
     return picklistFieldDetails;
 

--- a/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
+++ b/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
@@ -115,15 +115,24 @@ export class XmlFileProcessor {
 
   static extractPicklistDetailFromValueSetDefinition(valueSetDefinitionElement: any):IPicklistValue {
 
+    // FOR ALL USES OF "0" AS INDEX, THE XML PARSER IS LOOKING FOR 1 OR MANY TAGS SO WE ARE ONLY EXPECTED ONE BUT IT IS RETURNING AN ARRAY SO WE NEED TO GET THE FIRST INDEX OF '0'
     const picklistOptionApiName:string = valueSetDefinitionElement.fullName[0];
     const picklistLabel:string = valueSetDefinitionElement.label[0];
-    const picklistDefault:any = valueSetDefinitionElement.default ? valueSetDefinitionElement.default[0] : null;
-    const isPickListDefault:boolean = Boolean(picklistDefault === 'true' || picklistDefault === true);
+
+    // for below string to boolean conversions, stopped trying for the moment to get explicit conversion to work after tests continued to return string values
+
+    // "is picklist active" defaults to true if there is no <isActive> xml makrup that indicates false or true
+    const isPicklistActiveStringValue:any = valueSetDefinitionElement?.isActive ? valueSetDefinitionElement.isActive[0] : true;
+    const isPickListActive:boolean = Boolean(isPicklistActiveStringValue === 'true' || isPicklistActiveStringValue === true );
+    
+    const isPicklistDefaultStringValue:any = valueSetDefinitionElement.default ? valueSetDefinitionElement.default[0] : null;
+    const isPickListDefault:boolean = Boolean(isPicklistDefaultStringValue === 'true' || isPicklistDefaultStringValue === true);
 
     let picklistDetail: IPicklistValue = {
       picklistOptionApiName: picklistOptionApiName,
       label: picklistLabel,
-      default: isPickListDefault
+      default: isPickListDefault,
+      isActive: isPickListActive
     };
 
     return picklistDetail;
@@ -161,14 +170,7 @@ export class XmlFileProcessor {
       let controlllingValuesDependentPicklistIndividualValueIsAvailableFor:string[] = null;
       if (controllingValuesFromParentPicklistThatAllowThisPicklistValue && controllingValuesFromParentPicklistThatAllowThisPicklistValue.length > 0) { {
 
-        if ( !controllingValuesFromParentPicklistThatAllowThisPicklistValue[0]?.controllingFieldValue ) {
-          // IF THERE IS A CONTROLLING FIELD VALUE THEN WE CAN EXPECT THERE TO BE A DEPENDENT PICKLIST
-          // THERE CAN BE INSTANCES WHERE CONTROLLING FIELD IS SELECTED BUT NO VALUE SETTINGS ARE MADE AND SO WE NEED TO MANAGE FOR BOTH
-          console.log(controllingValuesFromParentPicklistThatAllowThisPicklistValue);
-        }
-
         controlllingValuesDependentPicklistIndividualValueIsAvailableFor = controllingValuesFromParentPicklistThatAllowThisPicklistValue[0].controllingFieldValue;
-        // picklistDetail.controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection = availableForControllingValuesettings;
         
       }
 

--- a/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
+++ b/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
@@ -4,58 +4,84 @@ import { IPicklistValue } from "../ObjectInfoWrapper/FieldInfo";
 
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { ErrorHandlingService } from "../ErrorHandlingService/ErrorHandlingService";
+
 
 export class XmlFileProcessor {
 
-  static async processXmlFieldContent(xmlContent: string): Promise<XMLFieldDetail> {
+  static async processXmlFieldContent(xmlContent: string, xmlFieldFileName: string): Promise<XMLFieldDetail> {
 
     let xmlFieldDetail = new XMLFieldDetail();
   
-    let fieldXML: any;
-    let parseString = xml2js.parseString;
-    parseString(xmlContent, function (error, result) {
+    try {
+  
+      xmlFieldDetail.xmlMarkup = xmlContent;
 
-      if (error) { 
-        throw new Error(`Error processing xmlContent ${xmlContent}:` + error);
-      }
+      let fieldXML: any;
+      let parseString = xml2js.parseString;
+      parseString(xmlContent, function (error, result) {
 
-      fieldXML = result;
-
-    });
-
-    const typeValue = fieldXML?.CustomField?.type?.[0] ?? "AUTO_GENERATED";
-    const fieldLabel = fieldXML?.CustomField?.label?.[0] ?? "AUTO_GENERATED";
-    
-    const apiName = fieldXML.CustomField.fullName[0];
-
-    xmlFieldDetail.fieldType = typeValue;
-    xmlFieldDetail.fieldLabel = fieldLabel;
-    xmlFieldDetail.apiName = apiName;
-
-    if ( typeValue === 'Picklist' || typeValue === "MultiselectPicklist") {
-
-      let picklistValueSetMarkup = fieldXML.CustomField.valueSet?.[0];
-
-      if (picklistValueSetMarkup) {
-        xmlFieldDetail.picklistValues = this.extractPickListDetailsFromXMLValueTag(picklistValueSetMarkup);
-
-        const controllingFieldApiName = picklistValueSetMarkup.controllingField ? picklistValueSetMarkup.controllingField[0]: null;
-        if (controllingFieldApiName) {
-          xmlFieldDetail.controllingField = controllingFieldApiName;
+        if (error) { 
+          throw new Error(`Error processing xmlContent ${xmlContent}:` + error);
         }
-      } else {
-        // TODO: handle possible global picklist scenario
+
+        fieldXML = result;
+
+      });
+
+      const apiName = fieldXML.CustomField.fullName[0];
+      xmlFieldDetail.apiName = apiName;
+
+      const typeValue = fieldXML?.CustomField?.type?.[0] ?? "AUTO_GENERATED";
+      const fieldLabel = fieldXML?.CustomField?.label?.[0] ?? "AUTO_GENERATED";
+      xmlFieldDetail.fieldType = typeValue;
+      xmlFieldDetail.fieldLabel = fieldLabel;
+
+      if ( typeValue === 'Picklist' || typeValue === "MultiselectPicklist") {
+
+        let picklistValueSetMarkup = fieldXML.CustomField.valueSet?.[0];
+
+        if (picklistValueSetMarkup) {
+          xmlFieldDetail.picklistValues = this.extractPickListDetailsFromXMLValueTag(picklistValueSetMarkup);
+
+          const controllingFieldApiName = picklistValueSetMarkup.controllingField ? picklistValueSetMarkup.controllingField[0]: null;
+          if (controllingFieldApiName) {
+            xmlFieldDetail.controllingField = controllingFieldApiName;
+          }
+
+        } else {
+          // TODO: handle possible global picklist scenario
+        }
+        
+        
+      } else if ( typeValue === "Lookup" || typeValue === "MasterDetail" ) {
+        
+        const referenceTo = fieldXML.CustomField.referenceTo? fieldXML.CustomField.referenceTo[0] : null;
+        xmlFieldDetail.referenceTo = referenceTo;
+
       }
       
-      
-    } else if ( typeValue === "Lookup" || typeValue === "MasterDetail" ) {
-      
-      const referenceTo = fieldXML.CustomField.referenceTo? fieldXML.CustomField.referenceTo[0] : null;
-      xmlFieldDetail.referenceTo = referenceTo;
+      return xmlFieldDetail;
 
+    } catch (error) {
+
+      const executedCommand = "XMLFileProcessor.processXmlFieldContent";
+      const customErrorMessage = `Error processing XML file: ${xmlFieldFileName} - ${error.message}`;
+      
+      const customXMLFieldError = new Error();
+      customXMLFieldError.message = customErrorMessage;
+
+      customXMLFieldError.name = "XMLFieldProcessorError";
+      customXMLFieldError.stack = error.stack;
+
+      customXMLFieldError.cause = xmlFieldDetail;
+
+      ErrorHandlingService.createGenerateRecipeErrorCaptureFile(customXMLFieldError, executedCommand);
+      
+      throw customXMLFieldError;
+      
     }
     
-    return xmlFieldDetail;
 
   }
 
@@ -65,37 +91,50 @@ export class XmlFileProcessor {
     let picklistFieldDetails:IPicklistValue[] = [];
   
     let picklistValues = picklistValueSetMarkup.valueSetDefinition[0].value;
-    picklistValues.forEach(element => {
-            
-      const picklistApiFullName:string = element.fullName[0];
-      const picklistLabel:string = element.label[0];
-      const picklistDefault:any = element.default ? element.default[0] : null;
-      const isPickListDefault:boolean = Boolean(picklistDefault === 'true' || picklistDefault === true);
-
-      let picklistDetail: IPicklistValue = {
-        fullName: picklistApiFullName,
-        label: picklistLabel,
-        default: isPickListDefault
-      };
-
-      if ( picklistValueSetMarkup.controllingField ) {
-        // IF THERE IS A CONTROLLING FIELD THEN WE CAN EXPECT THERE TO BE A DEPENDENT PICKLIST
-        // THERE CAN BE INSTANCES WHERE CONTROLLING FIELD IS SELECTED BUT NO VALUE SETTINGS ARE MADE AND SO WE NEED TO MANAGE FOR BOTH
-        let availableForControllingValuesForPicklistOption = picklistValueSetMarkup.valueSettings?.filter( 
-          (dependentPicklistSetting) => dependentPicklistSetting.valueName[0] === picklistApiFullName
-        );
-        if (availableForControllingValuesForPicklistOption) {
-          let availableForControllingValuesettings:string[] = availableForControllingValuesForPicklistOption[0].controllingFieldValue;
-          picklistDetail.availableForControllingValues = availableForControllingValuesettings;
-        }
-
-      }
-
+    picklistValues.forEach(valueSetDefinitionElement => {
+      
+      const picklistDetail = this.extractPicklistDetailFromValueSetDefinition(picklistValueSetMarkup, valueSetDefinitionElement);
       picklistFieldDetails.push(picklistDetail);
+      
   
     });
 
     return picklistFieldDetails;
+
+  }
+
+  static extractPicklistDetailFromValueSetDefinition(picklistValueSetMarkup: any, valueSetDefinitionElement: any):IPicklistValue {
+
+    const picklistApiFullName:string = valueSetDefinitionElement.fullName[0];
+    const picklistLabel:string = valueSetDefinitionElement.label[0];
+    const picklistDefault:any = valueSetDefinitionElement.default ? valueSetDefinitionElement.default[0] : null;
+    const isPickListDefault:boolean = Boolean(picklistDefault === 'true' || picklistDefault === true);
+
+    let picklistDetail: IPicklistValue = {
+      fullName: picklistApiFullName,
+      label: picklistLabel,
+      default: isPickListDefault
+    };
+
+    if ( picklistValueSetMarkup.controllingField ) {
+      // IF THERE IS A CONTROLLING FIELD THEN WE CAN EXPECT THERE TO BE A DEPENDENT PICKLIST
+      // THERE CAN BE INSTANCES WHERE CONTROLLING FIELD IS SELECTED BUT NO VALUE SETTINGS ARE MADE AND SO WE NEED TO MANAGE FOR BOTH
+      let availableForControllingValuesForPicklistOption = picklistValueSetMarkup.valueSettings?.filter( 
+        (dependentPicklistSetting) => dependentPicklistSetting.valueName[0] === picklistApiFullName
+      );
+      if (availableForControllingValuesForPicklistOption) {
+        if ( !availableForControllingValuesForPicklistOption[0]?.controllingFieldValue ) {
+          // IF THERE IS A CONTROLLING FIELD VALUE THEN WE CAN EXPECT THERE TO BE A DEPENDENT PICKLIST
+          // THERE CAN BE INSTANCES WHERE CONTROLLING FIELD IS SELECTED BUT NO VALUE SETTINGS ARE MADE AND SO WE NEED TO MANAGE FOR BOTH
+          console.log(availableForControllingValuesForPicklistOption);
+        }
+        let availableForControllingValuesettings:string[] = availableForControllingValuesForPicklistOption[0].controllingFieldValue;
+        picklistDetail.availableForControllingValues = availableForControllingValuesettings;
+      }
+
+    }
+
+    return picklistDetail;
 
   }
 

--- a/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
+++ b/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
@@ -94,7 +94,7 @@ export class XmlFileProcessor {
     picklistValues.forEach(valueSetDefinitionElement => {
       
       const picklistDetail = this.extractPicklistDetailFromValueSetDefinition(valueSetDefinitionElement);
-      const dependentPicklistConfigurationExists = picklistValueSetMarkup.controllingField;
+      const dependentPicklistConfigurationExists = ( picklistValueSetMarkup?.controllingField.length === 1 );
       // IF THERE IS A CONTROLLING FIELD THEN WE CAN EXPECT THERE TO BE A DEPENDENT PICKLIST CONFIGURATION
       if (dependentPicklistConfigurationExists) {
           const dependentPicklistConfigurationDetail = this.getDependentPicklistConfigurationDetailByPicklistDetail(picklistDetail.picklistOptionApiName, picklistValueSetMarkup);

--- a/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
@@ -32,6 +32,7 @@ describe('extractPickListDetailsFromXMLValueTag',() => {
         actualPicklistDetail.forEach((picklistOption, index) => {
             expect(picklistOption.picklistOptionApiName).toBe(expectedPicklistOptionDetails[index].picklistOptionApiName); 
         });
+
     });
 
     test('given test expected picklist xml markup, returns expected IPickList array', async () => {
@@ -53,6 +54,21 @@ describe('extractPickListDetailsFromXMLValueTag',() => {
         actualPicklistDetail.forEach((picklistOption, index) => {
             expect(picklistOption.picklistOptionApiName).toBe(expectedPicklistFieldDetails[index].picklistOptionApiName); 
         });
+
+        // THE BELOW ASSERTS ARE USED TO ENSURE THE PICKLIST DETAIL CAPTURES MARKUP LIKLE "isActive" AND SCENARIOS WHERE PICKLIST VALUE OPTIONS HAVE ZERO CONTROLLING FIELD CONFIGURATIONS FROM THE EXPECTED PARENT PICKLIST
+        let countOfNullControllingPicklistOptions = expectedPicklistFieldDetails?.filter( 
+            (picklistOptionDetail) => picklistOptionDetail.controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection === null
+        );
+        const expectedHardCodedCountOfNullControllingPicklistOptions = 3;
+        expect(countOfNullControllingPicklistOptions.length).toBe(expectedHardCodedCountOfNullControllingPicklistOptions);
+
+
+        let countOfIsNotActivePicklistOptions = expectedPicklistFieldDetails?.filter( 
+            (picklistOptionDetail) => picklistOptionDetail.isActive === false
+        );
+        const expectedHardCodedCountOfIsNotActiveOptions = 2;
+        expect(countOfIsNotActivePicklistOptions.length).toBe(expectedHardCodedCountOfIsNotActiveOptions);
+
         
     });
 
@@ -70,12 +86,9 @@ describe('extractPickListDetailsFromXMLValueTag',() => {
         const xmlPicklistValueSet: any[] = expectedPicklistFieldXML.CustomField.valueSet[0];
         const actualPicklistDetail = XmlFileProcessor.extractPickListDetailsFromXMLValueTag(xmlPicklistValueSet);
         
-        const expectedPicklistOptionFieldDetails = XMLMarkupMockService.getIPicklistValuesForPicklist__c();
-
-        expect(actualPicklistDetail.length).toBe(expectedPicklistOptionFieldDetails.length);
-        actualPicklistDetail.forEach((picklistOption, index) => {
-            expect(picklistOption.picklistOptionApiName).toBe(expectedPicklistOptionFieldDetails[index].picklistOptionApiName); 
-        });
+        // THERE SHOULD BE NO PICKLIST DETAILS COMING FROM XML MARKUP SET TO GLOVAL VALUE SET
+        const hardCodedLengthOfPicklistDetails = 0;
+        expect(actualPicklistDetail.length).toBe(hardCodedLengthOfPicklistDetails);
         
     });
 
@@ -108,6 +121,28 @@ describe('processXmlFieldContent', () => {
     test('given expected Dependent Picklist xml markup, returns expected Dependent picklist XMLFieldDetail', async () => {
 
         const xmlDependentPicklistMarkup = XMLMarkupMockService.getDependentPicklistFieldTypeXMLMarkup();
+        const fakeFieldName = 'DependentPicklist__c.field-meta.xml';
+        const actualDependentPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlDependentPicklistMarkup, fakeFieldName);
+        const expectedXMLDependentPicklistXMLFieldDetail = XMLMarkupMockService.getDependentPicklistXMLFieldDetail();
+
+        expect(expectedXMLDependentPicklistXMLFieldDetail).toEqual(actualDependentPicklistDetail);
+
+    });
+
+    test('given expected Dependent Picklist with isActive tags in xml markup, returns expected Dependent picklist XMLFieldDetail', async () => {
+
+        const xmlDependentPicklistMarkup = XMLMarkupMockService.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
+        const fakeFieldName = 'DependentPicklist__c.field-meta.xml';
+        const actualDependentPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlDependentPicklistMarkup, fakeFieldName);
+        const expectedXMLDependentPicklistXMLFieldDetail = XMLMarkupMockService.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
+
+        expect(expectedXMLDependentPicklistXMLFieldDetail).toEqual(actualDependentPicklistDetail);
+
+    });
+
+    test('given expected Global Value Set xml markup, returns expected picklist XMLFieldDetail', async () => {
+
+        const xmlDependentPicklistMarkup = XMLMarkupMockService.getGlobalValueSetXMLMarkup();
         const fakeFieldName = 'DependentPicklist__c.field-meta.xml';
         const actualDependentPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlDependentPicklistMarkup, fakeFieldName);
         const expectedXMLDependentPicklistXMLFieldDetail = XMLMarkupMockService.getDependentPicklistXMLFieldDetail();

--- a/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
@@ -41,7 +41,8 @@ describe('processXmlFieldContent', () => {
     test('given expected Picklist xml markup, returns expected picklist XMLFieldDetail', async () => {
 
         const xmlPicklistMarkup = XMLMarkupMockService.getPicklistFieldTypeXMLMarkup();
-        const actualPicklistXMLFieldDetail:XMLFieldDetail = await await XmlFileProcessor.processXmlFieldContent(xmlPicklistMarkup);
+        const fakeFieldName = 'Picklist__c.field-meta.xml';
+        const actualPicklistXMLFieldDetail:XMLFieldDetail = await await XmlFileProcessor.processXmlFieldContent(xmlPicklistMarkup, fakeFieldName);
         const expectedXMLPicklistXMLFieldDetail:XMLFieldDetail = XMLMarkupMockService.getPicklistXMLFieldDetail();
 
         expect(actualPicklistXMLFieldDetail).toEqual(expectedXMLPicklistXMLFieldDetail);
@@ -51,7 +52,8 @@ describe('processXmlFieldContent', () => {
     test('given expected Multi-Select Picklist xml markup, returns expected picklist XMLFieldDetail', async () => {
 
         const xmlMultiSelectPicklistMarkup = XMLMarkupMockService.getMultiSelectPicklistFieldTypeXMLMarkup();
-        const actualMultiSelectPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlMultiSelectPicklistMarkup);
+        const fakeFieldName = 'MultiSelectPicklist__c.field-meta.xml';
+        const actualMultiSelectPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlMultiSelectPicklistMarkup, fakeFieldName);
         const expectedXMLMultiSelectPicklistXMLFieldDetail = XMLMarkupMockService.getMultiSelectPicklistXMLFieldDetail();
 
         expect(actualMultiSelectPicklistDetail).toEqual(expectedXMLMultiSelectPicklistXMLFieldDetail);
@@ -61,7 +63,8 @@ describe('processXmlFieldContent', () => {
     test('given expected Dependent Picklist xml markup, returns expected Dependent picklist XMLFieldDetail', async () => {
 
         const xmlDependentPicklistMarkup = XMLMarkupMockService.getDependentPicklistFieldTypeXMLMarkup();
-        const actualDependentPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlDependentPicklistMarkup);
+        const fakeFieldName = 'DependentPicklist__c.field-meta.xml';
+        const actualDependentPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlDependentPicklistMarkup, fakeFieldName);
         const expectedXMLDependentPicklistXMLFieldDetail = XMLMarkupMockService.getDependentPicklistXMLFieldDetail();
 
         expect(expectedXMLDependentPicklistXMLFieldDetail).toEqual(actualDependentPicklistDetail);
@@ -71,7 +74,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Text" field type xml markup, returns expected text XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getTextFieldTypeXMLMarkup();
-        const actualTextDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Text__c.field-meta.xml';
+        const actualTextDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLFieldXMLFieldDetail = XMLMarkupMockService.getTextXMLFieldDetail();
 
         expect(actualTextDetail).toEqual(expectedXMLFieldXMLFieldDetail);
@@ -81,7 +85,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Checkbox" field type xml markup, returns expected Checkbox XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getCheckboxFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Checkbox.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLCheckboxFieldXMLFieldDetail = XMLMarkupMockService.getCheckboxFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLCheckboxFieldXMLFieldDetail);
@@ -91,7 +96,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Currency" field type xml markup, returns expected Currency XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getCurrencyFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Currency__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLCurrencyFieldXMLFieldDetail = XMLMarkupMockService.getCurrencyFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLCurrencyFieldXMLFieldDetail);
@@ -101,7 +107,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Date" field type xml markup, returns expected Date XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getDateFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Date__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLDateFieldXMLFieldDetail = XMLMarkupMockService.getDateFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLDateFieldXMLFieldDetail);
@@ -111,7 +118,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "DateTime" field type xml markup, returns expected DateTime XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getDateTimeFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'DateTime__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLDateTimeFieldXMLFieldDetail = XMLMarkupMockService.getDateTimeFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLDateTimeFieldXMLFieldDetail);
@@ -121,7 +129,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Email" field type xml markup, returns expected Email XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getEmailFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Email__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLEmailFieldXMLFieldDetail = XMLMarkupMockService.getEmailXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLEmailFieldXMLFieldDetail);
@@ -131,7 +140,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Lookup" field type xml markup, returns expected Lookup XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getLookupFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Lookup__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLLookupFieldXMLFieldDetail = XMLMarkupMockService.getLookupXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLLookupFieldXMLFieldDetail);
@@ -141,7 +151,8 @@ describe('processXmlFieldContent', () => {
     test('given expected Formula field with "Number" field type xml markup, returns expected Formula XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getFormulaFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Formula__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLFormulaFieldXMLFieldDetail = XMLMarkupMockService.getFormulaXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLFormulaFieldXMLFieldDetail);
@@ -152,7 +163,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Geolocation" field type xml markup, returns expected Geolocation XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getGeolocationFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Geolocation__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLGeolocationFieldXMLFieldDetail = XMLMarkupMockService.getGeolocationXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLGeolocationFieldXMLFieldDetail);
@@ -162,7 +174,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Number" field type xml markup, returns expected Number XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getNumberFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Number__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLNumberFieldXMLFieldDetail = XMLMarkupMockService.getNumberXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLNumberFieldXMLFieldDetail);
@@ -172,7 +185,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Phone" field type xml markup, returns expected Phone XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getPhoneFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Phone__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLPhoneFieldXMLFieldDetail = XMLMarkupMockService.getPhoneXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLPhoneFieldXMLFieldDetail);
@@ -182,7 +196,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Phone" field type xml markup, returns expected Phone XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getPhoneFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Phone__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLPhoneFieldXMLFieldDetail = XMLMarkupMockService.getPhoneXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLPhoneFieldXMLFieldDetail);
@@ -192,7 +207,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "LongTextArea" field type xml markup, returns expected LongTextArea XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getLongTextAreaFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'LongTextArea__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLLongTextAreaFieldXMLFieldDetail = XMLMarkupMockService.getLongTextAreaXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLLongTextAreaFieldXMLFieldDetail);
@@ -202,7 +218,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "RichTextArea" html field type xml markup, returns expected RichTextArea XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getRichTextAreaFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'RichTextArea__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLRichTextAreaFieldXMLFieldDetail = XMLMarkupMockService.getRichTextAreaXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLRichTextAreaFieldXMLFieldDetail);
@@ -212,7 +229,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Time" field type xml markup, returns expected Time XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getTimeFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Time__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLTimeFieldXMLFieldDetail = XMLMarkupMockService.getTimeXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLTimeFieldXMLFieldDetail);
@@ -223,7 +241,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "Url" field type xml markup, returns expected Url XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getUrlFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'Url__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLUrlFieldXMLFieldDetail = XMLMarkupMockService.getUrlXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLUrlFieldXMLFieldDetail);
@@ -233,7 +252,8 @@ describe('processXmlFieldContent', () => {
     test('given expected "MasterDetail" field type xml markup, returns expected MasterDetail XMLFieldDetail', async () => {
 
         const xmlFieldMarkup = XMLMarkupMockService.getMasterDetailFieldTypeXMLMarkup();
-        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup);
+        const fakeFieldName = 'MasterDetail__c.field-meta.xml';
+        const actualFieldDetail = await XmlFileProcessor.processXmlFieldContent(xmlFieldMarkup, fakeFieldName);
         const expectedXMLMasterDetailFieldXMLFieldDetail = XMLMarkupMockService.getMasterDetailXMLFieldDetail();
 
         expect(actualFieldDetail).toEqual(expectedXMLMasterDetailFieldXMLFieldDetail);

--- a/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
@@ -26,7 +26,7 @@ describe('extractPickListDetailsFromXMLValueTag',() => {
 
         const xmlPicklistValueSet: any[] = expectedPicklistFieldXML.CustomField.valueSet[0];
         const actualPicklistDetail = XmlFileProcessor.extractPickListDetailsFromXMLValueTag(xmlPicklistValueSet);
-        const expectedPicklistOptionDetails = XMLMarkupMockService.getIPicklistValuesForPickllist__c();
+        const expectedPicklistOptionDetails = XMLMarkupMockService.getIPicklistValuesForPicklist__c();
 
         expect(actualPicklistDetail.length).toBe(expectedPicklistOptionDetails.length);
         actualPicklistDetail.forEach((picklistOption, index) => {
@@ -36,22 +36,20 @@ describe('extractPickListDetailsFromXMLValueTag',() => {
 
     test('given test expected picklist xml markup, returns expected IPickList array', async () => {
 
-        // const xmlPicklistMarkup = XMLMarkupMockService.getTestdependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
         const xmlPicklistMarkup = XMLMarkupMockService.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
 
         let expectedPicklistFieldXML: any;
         const parseString = xml2js.parseString;
         parseString(xmlPicklistMarkup, function (err, result) {
-            console.dir(result);
             expectedPicklistFieldXML = result;
         });
 
         const xmlPicklistValueSet: any[] = expectedPicklistFieldXML.CustomField.valueSet[0];
         const actualPicklistDetail = XmlFileProcessor.extractPickListDetailsFromXMLValueTag(xmlPicklistValueSet);
         
-        const expectedPicklistFieldDetails = XMLMarkupMockService.getIPicklistValuesForPickllist__c();
-
+        const expectedPicklistFieldDetails = XMLMarkupMockService.getIPicklistValuesForDependentPickllist__c();
         expect(actualPicklistDetail.length).toBe(expectedPicklistFieldDetails.length);
+
         actualPicklistDetail.forEach((picklistOption, index) => {
             expect(picklistOption.picklistOptionApiName).toBe(expectedPicklistFieldDetails[index].picklistOptionApiName); 
         });
@@ -72,7 +70,7 @@ describe('extractPickListDetailsFromXMLValueTag',() => {
         const xmlPicklistValueSet: any[] = expectedPicklistFieldXML.CustomField.valueSet[0];
         const actualPicklistDetail = XmlFileProcessor.extractPickListDetailsFromXMLValueTag(xmlPicklistValueSet);
         
-        const expectedPicklistOptionFieldDetails = XMLMarkupMockService.getIPicklistValuesForPickllist__c();
+        const expectedPicklistOptionFieldDetails = XMLMarkupMockService.getIPicklistValuesForPicklist__c();
 
         expect(actualPicklistDetail.length).toBe(expectedPicklistOptionFieldDetails.length);
         actualPicklistDetail.forEach((picklistOption, index) => {

--- a/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
@@ -177,31 +177,23 @@ describe('processXmlFieldContent', () => {
     });
 
 
-
-
-
     test('given expected Global Value Set xml markup, returns expected picklist XMLFieldDetail', async () => {
 
         const xmlGlobalPicklistMarkup = XMLMarkupMockService.getGlobalValueSetXMLMarkup();
         const fakeFieldName = 'GlobalPicklist__c.field-meta.xml';
         const actualGlobalPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlGlobalPicklistMarkup, fakeFieldName);
         const expectedGlobalPicklistDetail = XMLMarkupMockService.getPicklistFieldSetToGlobalPicklistXMLFieldDetail();
+
         expect(actualGlobalPicklistDetail).toEqual(expectedGlobalPicklistDetail);
 
     });
 
-
-
-
-
-
-
     test('given expected Standard Value Set xml markup, returns expected picklist XMLFieldDetail', async () => {
 
-        const xmlDependentPicklistMarkup = XMLMarkupMockService.getStandardValueSetLeadSourceXMLMarkup();
+        const xmlStandardValueSetMarkup = XMLMarkupMockService.getStandardValueSetLeadSourceXMLMarkup();
         const fakeFieldName = 'LeadSource.field-meta.xml';
-        const actualDependentPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlDependentPicklistMarkup, fakeFieldName);
-        const expectedXMLDependentPicklistXMLFieldDetail = XMLMarkupMockService.getDependentPicklistXMLFieldDetail();
+        const actualDependentPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlStandardValueSetMarkup, fakeFieldName);
+        const expectedXMLDependentPicklistXMLFieldDetail = XMLMarkupMockService.getExpectedStandardValueSetLeadSourcePicklistXMLFieldDetail();
 
         expect(expectedXMLDependentPicklistXMLFieldDetail).toEqual(actualDependentPicklistDetail);
 

--- a/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
@@ -26,12 +26,59 @@ describe('extractPickListDetailsFromXMLValueTag',() => {
 
         const xmlPicklistValueSet: any[] = expectedPicklistFieldXML.CustomField.valueSet[0];
         const actualPicklistDetail = XmlFileProcessor.extractPickListDetailsFromXMLValueTag(xmlPicklistValueSet);
+        const expectedPicklistOptionDetails = XMLMarkupMockService.getIPicklistValuesForPickllist__c();
+
+        expect(actualPicklistDetail.length).toBe(expectedPicklistOptionDetails.length);
+        actualPicklistDetail.forEach((picklistOption, index) => {
+            expect(picklistOption.picklistOptionApiName).toBe(expectedPicklistOptionDetails[index].picklistOptionApiName); 
+        });
+    });
+
+    test('given test expected picklist xml markup, returns expected IPickList array', async () => {
+
+        // const xmlPicklistMarkup = XMLMarkupMockService.getTestdependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
+        const xmlPicklistMarkup = XMLMarkupMockService.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
+
+        let expectedPicklistFieldXML: any;
+        const parseString = xml2js.parseString;
+        parseString(xmlPicklistMarkup, function (err, result) {
+            console.dir(result);
+            expectedPicklistFieldXML = result;
+        });
+
+        const xmlPicklistValueSet: any[] = expectedPicklistFieldXML.CustomField.valueSet[0];
+        const actualPicklistDetail = XmlFileProcessor.extractPickListDetailsFromXMLValueTag(xmlPicklistValueSet);
+        
         const expectedPicklistFieldDetails = XMLMarkupMockService.getIPicklistValuesForPickllist__c();
 
         expect(actualPicklistDetail.length).toBe(expectedPicklistFieldDetails.length);
-        actualPicklistDetail.forEach((item, index) => {
-            expect(item.fullName).toBe(expectedPicklistFieldDetails[index].fullName); 
+        actualPicklistDetail.forEach((picklistOption, index) => {
+            expect(picklistOption.picklistOptionApiName).toBe(expectedPicklistFieldDetails[index].picklistOptionApiName); 
         });
+        
+    });
+
+    test('given global value set picklist xml markup, returns expected IPickList array', async () => {
+
+        const xmlPicklistMarkup = XMLMarkupMockService.getGlobalValueSetXMLMarkup();
+
+        let expectedPicklistFieldXML: any;
+        const parseString = xml2js.parseString;
+        parseString(xmlPicklistMarkup, function (err, result) {
+            console.dir(result);
+            expectedPicklistFieldXML = result;
+        });
+
+        const xmlPicklistValueSet: any[] = expectedPicklistFieldXML.CustomField.valueSet[0];
+        const actualPicklistDetail = XmlFileProcessor.extractPickListDetailsFromXMLValueTag(xmlPicklistValueSet);
+        
+        const expectedPicklistOptionFieldDetails = XMLMarkupMockService.getIPicklistValuesForPickllist__c();
+
+        expect(actualPicklistDetail.length).toBe(expectedPicklistOptionFieldDetails.length);
+        actualPicklistDetail.forEach((picklistOption, index) => {
+            expect(picklistOption.picklistOptionApiName).toBe(expectedPicklistOptionFieldDetails[index].picklistOptionApiName); 
+        });
+        
     });
 
 });

--- a/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts
@@ -35,9 +35,9 @@ describe('extractPickListDetailsFromXMLValueTag',() => {
 
     });
 
-    test('given test expected picklist xml markup, returns expected IPickList array', async () => {
+    test('given expected dependent picklist xml markup, returns expected IPickList array', async () => {
 
-        const xmlPicklistMarkup = XMLMarkupMockService.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
+        const xmlPicklistMarkup = XMLMarkupMockService.getDependentPicklistFieldTypeXMLMarkup();
 
         let expectedPicklistFieldXML: any;
         const parseString = xml2js.parseString;
@@ -59,9 +59,45 @@ describe('extractPickListDetailsFromXMLValueTag',() => {
         let countOfNullControllingPicklistOptions = expectedPicklistFieldDetails?.filter( 
             (picklistOptionDetail) => picklistOptionDetail.controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection === null
         );
-        const expectedHardCodedCountOfNullControllingPicklistOptions = 3;
+        const expectedHardCodedCountOfNullControllingPicklistOptions = 0;
         expect(countOfNullControllingPicklistOptions.length).toBe(expectedHardCodedCountOfNullControllingPicklistOptions);
 
+
+        let countOfIsNotActivePicklistOptions = expectedPicklistFieldDetails?.filter( 
+            (picklistOptionDetail) => picklistOptionDetail.isActive === false
+        );
+        const expectedHardCodedCountOfIsNotActiveOptions = 0;
+        expect(countOfIsNotActivePicklistOptions.length).toBe(expectedHardCodedCountOfIsNotActiveOptions);
+
+        
+    });
+
+    test('given expected dependent picklist with isActive xml markup, returns expected IPickList array', async () => {
+
+        const xmlPicklistMarkup = XMLMarkupMockService.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
+
+        let expectedPicklistFieldXML: any;
+        const parseString = xml2js.parseString;
+        parseString(xmlPicklistMarkup, function (err, result) {
+            expectedPicklistFieldXML = result;
+        });
+
+        const xmlPicklistValueSet: any[] = expectedPicklistFieldXML.CustomField.valueSet[0];
+        const actualPicklistDetail = XmlFileProcessor.extractPickListDetailsFromXMLValueTag(xmlPicklistValueSet);
+        
+        const expectedPicklistFieldDetails = XMLMarkupMockService.getIPicklistValuesWithIsActiveConfigDependentPickllist__c();
+        expect(actualPicklistDetail.length).toBe(expectedPicklistFieldDetails.length);
+
+        actualPicklistDetail.forEach((picklistOption, index) => {
+            expect(picklistOption.picklistOptionApiName).toBe(expectedPicklistFieldDetails[index].picklistOptionApiName); 
+        });
+
+        // THE BELOW ASSERTS ARE USED TO ENSURE THE PICKLIST DETAIL CAPTURES MARKUP LIKLE "isActive" AND SCENARIOS WHERE PICKLIST VALUE OPTIONS HAVE ZERO CONTROLLING FIELD CONFIGURATIONS FROM THE EXPECTED PARENT PICKLIST
+        let countOfNullControllingPicklistOptions = expectedPicklistFieldDetails?.filter( 
+            (picklistOptionDetail) => picklistOptionDetail.controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection === null
+        );
+        const expectedHardCodedCountOfNullControllingPicklistOptions = 2;
+        expect(countOfNullControllingPicklistOptions.length).toBe(expectedHardCodedCountOfNullControllingPicklistOptions);
 
         let countOfIsNotActivePicklistOptions = expectedPicklistFieldDetails?.filter( 
             (picklistOptionDetail) => picklistOptionDetail.isActive === false
@@ -71,6 +107,7 @@ describe('extractPickListDetailsFromXMLValueTag',() => {
 
         
     });
+
 
     test('given global value set picklist xml markup, returns expected IPickList array', async () => {
 
@@ -131,19 +168,38 @@ describe('processXmlFieldContent', () => {
 
     test('given expected Dependent Picklist with isActive tags in xml markup, returns expected Dependent picklist XMLFieldDetail', async () => {
 
-        const xmlDependentPicklistMarkup = XMLMarkupMockService.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
+        const xmlExpectedDependentPicklistMarkup = XMLMarkupMockService.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
         const fakeFieldName = 'DependentPicklist__c.field-meta.xml';
-        const actualDependentPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlDependentPicklistMarkup, fakeFieldName);
-        const expectedXMLDependentPicklistXMLFieldDetail = XMLMarkupMockService.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup();
+        const actualDependentPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlExpectedDependentPicklistMarkup, fakeFieldName);
+        const expectedXMLDependentPicklistXMLFieldDetail:XMLFieldDetail = XMLMarkupMockService.getExpectedIsActiveDependentPicklistXMLDetail();
 
-        expect(expectedXMLDependentPicklistXMLFieldDetail).toEqual(actualDependentPicklistDetail);
-
+        expect(actualDependentPicklistDetail).toEqual(expectedXMLDependentPicklistXMLFieldDetail);
     });
+
+
+
+
 
     test('given expected Global Value Set xml markup, returns expected picklist XMLFieldDetail', async () => {
 
-        const xmlDependentPicklistMarkup = XMLMarkupMockService.getGlobalValueSetXMLMarkup();
-        const fakeFieldName = 'DependentPicklist__c.field-meta.xml';
+        const xmlGlobalPicklistMarkup = XMLMarkupMockService.getGlobalValueSetXMLMarkup();
+        const fakeFieldName = 'GlobalPicklist__c.field-meta.xml';
+        const actualGlobalPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlGlobalPicklistMarkup, fakeFieldName);
+        const expectedGlobalPicklistDetail = XMLMarkupMockService.getPicklistFieldSetToGlobalPicklistXMLFieldDetail();
+        expect(actualGlobalPicklistDetail).toEqual(expectedGlobalPicklistDetail);
+
+    });
+
+
+
+
+
+
+
+    test('given expected Standard Value Set xml markup, returns expected picklist XMLFieldDetail', async () => {
+
+        const xmlDependentPicklistMarkup = XMLMarkupMockService.getStandardValueSetLeadSourceXMLMarkup();
+        const fakeFieldName = 'LeadSource.field-meta.xml';
         const actualDependentPicklistDetail = await XmlFileProcessor.processXmlFieldContent(xmlDependentPicklistMarkup, fakeFieldName);
         const expectedXMLDependentPicklistXMLFieldDetail = XMLMarkupMockService.getDependentPicklistXMLFieldDetail();
 

--- a/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
@@ -332,6 +332,21 @@ export class XMLMarkupMockService {
         return dependentPicklistXMLField;      
     }
 
+    static getDependentPicklistWithIsActiveXMLFieldDetail() {
+
+        const mockedMultiSelectPicklistValues = this.getIPicklistValuesWithIsActiveConfigDependentPickllist__c();
+        const dependentPicklistXMLField: XMLFieldDetail = {
+            fieldType: "Picklist",
+            apiName: "DependentPicklist__c",
+            picklistValues: mockedMultiSelectPicklistValues,
+            fieldLabel: "DependentPicklist",
+            controllingField: "Picklist__c",
+            xmlMarkup: this.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup()
+        };
+
+        return dependentPicklistXMLField;      
+    }
+
     static getDependentPicklistFieldTypeXMLMarkup() {
         const xmlMarkup = `
 <?xml version="1.0" encoding="UTF-8"?>
@@ -439,7 +454,7 @@ export class XMLMarkupMockService {
             <value>
                 <fullName>fancystone</fullName>
                 <default>false</default>
-                <isActive>hedges</isActive>
+                <isActive>false</isActive>
                 <label>fancystone</label>
             </value>
             <value>
@@ -545,6 +560,67 @@ export class XMLMarkupMockService {
                 default: false,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle',  'wickliffe']
             }
+       
+        ];
+
+        return expectedPicklistFieldDetails;
+    
+    }
+
+    static getIPicklistValuesWithIsActiveConfigDependentPickllist__c(): IPicklistValue[] {
+        
+        const expectedPicklistFieldDetails:IPicklistValue[] = [
+            {
+                picklistOptionApiName: 'tree',
+                label: 'tree',
+                default: false,
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'willoughby']
+            },
+            {
+                picklistOptionApiName: 'plant',
+                label: 'plant',
+                default: false,
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['madison', 'mentor']
+            },
+            {
+                picklistOptionApiName: 'fancystone',
+                label: 'fancystone',
+                default: false,
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: null,
+                isActive: false
+            },
+            {
+                picklistOptionApiName: 'weed',
+                label: 'weed',
+                default: false,
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'mentor', 'wickliffe', 'willoughby']
+            },
+            {
+                picklistOptionApiName: 'mulch',
+                label: 'mulch',
+                default: false,
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'willoughby']
+            },
+            {
+                picklistOptionApiName: 'rocks',
+                label: 'rocks',
+                default: false,
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle',  'wickliffe']
+            },
+            {
+                picklistOptionApiName: 'moss',
+                label: 'moss',
+                default: false,
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: null,
+                isActive: false
+            },
+            {
+                picklistOptionApiName: 'hedges',
+                label: 'hedges',
+                default: false,
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: null,
+                isActive: true
+            },
        
         ];
 

--- a/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
@@ -517,6 +517,11 @@ export class XMLMarkupMockService {
             <controllingFieldValue>mentor</controllingFieldValue>
             <valueName>plant</valueName>
         </valueSettings>
+        <valueSettings>
+            <controllingFieldValue>cle</controllingFieldValue>
+            <controllingFieldValue>eastlake</controllingFieldValue>
+            <valueName>hedges</valueName>
+        </valueSettings>
     </valueSet>
 </CustomField>
 `;
@@ -525,7 +530,21 @@ export class XMLMarkupMockService {
     
     }
 
-   
+    static getExpectedIsActiveDependentPicklistXMLDetail():XMLFieldDetail {
+        
+        const mockedMultiSelectPicklistValues = this.getIPicklistValuesWithIsActiveConfigDependentPickllist__c();
+        const dependentPicklistXMLField: XMLFieldDetail = {
+            fieldType: "Picklist",
+            apiName: "DependentPicklist__c",
+            picklistValues: mockedMultiSelectPicklistValues,
+            fieldLabel: "DependentPicklist",
+            controllingField: "Picklist__c",
+            xmlMarkup: this.getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup()
+        };
+
+        return dependentPicklistXMLField;         
+    
+    }
 
     static getIPicklistValuesForDependentPickllist__c(): IPicklistValue[] {
         
@@ -534,30 +553,35 @@ export class XMLMarkupMockService {
                 picklistOptionApiName: 'tree',
                 label: 'tree',
                 default: false,
+                isActive: true,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'willoughby']
             },
             {
                 picklistOptionApiName: 'plant',
                 label: 'plant',
                 default: false,
+                isActive: true,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['madison', 'mentor']
             },
             {
                 picklistOptionApiName: 'weed',
                 label: 'weed',
                 default: false,
+                isActive: true,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'mentor', 'wickliffe', 'willoughby']
             },
             {
                 picklistOptionApiName: 'mulch',
                 label: 'mulch',
                 default: false,
+                isActive: true,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'willoughby']
             },
             {
                 picklistOptionApiName: 'rocks',
                 label: 'rocks',
                 default: false,
+                isActive: true,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle',  'wickliffe']
             }
        
@@ -574,12 +598,14 @@ export class XMLMarkupMockService {
                 picklistOptionApiName: 'tree',
                 label: 'tree',
                 default: false,
+                isActive: true,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'willoughby']
             },
             {
                 picklistOptionApiName: 'plant',
                 label: 'plant',
                 default: false,
+                isActive: true,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['madison', 'mentor']
             },
             {
@@ -593,18 +619,21 @@ export class XMLMarkupMockService {
                 picklistOptionApiName: 'weed',
                 label: 'weed',
                 default: false,
+                isActive: true,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'mentor', 'wickliffe', 'willoughby']
             },
             {
                 picklistOptionApiName: 'mulch',
                 label: 'mulch',
                 default: false,
+                isActive: true,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'willoughby']
             },
             {
                 picklistOptionApiName: 'rocks',
                 label: 'rocks',
                 default: false,
+                isActive: true,
                 controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle',  'wickliffe']
             },
             {
@@ -618,14 +647,28 @@ export class XMLMarkupMockService {
                 picklistOptionApiName: 'hedges',
                 label: 'hedges',
                 default: false,
-                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: null,
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake'],
                 isActive: true
-            },
+            }
        
         ];
 
         return expectedPicklistFieldDetails;
     
+    }
+
+    static getPicklistFieldSetToGlobalPicklistXMLFieldDetail() {
+
+        const dependentPicklistXMLField: XMLFieldDetail = {
+            fieldType: "Picklist",
+            apiName: "ValueSetPicklist",
+            globalValueSetName: 'Value_Set_Picklist_VS',
+            picklistValues: [],
+            fieldLabel: "Value Set Picklist",
+            xmlMarkup: this.getGlobalValueSetXMLMarkup()
+        };
+
+        return dependentPicklistXMLField;      
     }
 
     static getGlobalValueSetXMLMarkup() {
@@ -649,6 +692,21 @@ export class XMLMarkupMockService {
 
         return xmlMarkup;
     }
+
+    static getStandardValueSetLeadSourceXMLMarkup() {
+
+        const xmlMarkup = `                     
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>LeadSource</fullName>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Picklist</type>
+</CustomField>
+`;
+
+        return xmlMarkup;
+    }
+
 
     static getEmailXMLFieldDetail() {
         
@@ -945,32 +1003,38 @@ export class XMLMarkupMockService {
             {
                 picklistOptionApiName: 'cle',
                 label: 'cle',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'eastlake',
                 label: 'eastlake',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'madison',
                 label: 'madison',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'mentor',
                 label: 'mentor',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'wickliffe',
                 label: 'wickliffe',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'willoughby',
                 label: 'willoughby',
-                default: false
+                default: false,
+                isActive: true
             }
             
 
@@ -986,37 +1050,44 @@ export class XMLMarkupMockService {
             {
                 picklistOptionApiName: 'chicken',
                 label: 'chicken',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'chorizo',
                 label: 'chorizo',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'egg',
                 label: 'egg',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'fish',
                 label: 'fish',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'pork',
                 label: 'pork',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'steak',
                 label: 'steak',
-                default: false
+                default: false,
+                isActive: true
             },
             {
                 picklistOptionApiName: 'tofu',
                 label: 'tofu',
-                default: false
+                default: false,
+                isActive: true
             }
         ];
 

--- a/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
@@ -475,7 +475,8 @@ export class XMLMarkupMockService {
         let xmlFieldDetail: XMLFieldDetail = {
             fieldType: "DateTime",
             apiName: "DateTime__c",
-            fieldLabel: "DateTime"
+            fieldLabel: "DateTime",
+            xmlMarkup: this.getDateTimeFieldTypeXMLMarkup()
         };
 
         return xmlFieldDetail;
@@ -503,7 +504,8 @@ export class XMLMarkupMockService {
         let xmlFieldDetail: XMLFieldDetail = {
             fieldType: "Date",
             apiName: "Date__c",
-            fieldLabel: "Date"
+            fieldLabel: "Date",
+            xmlMarkup: this.getDateFieldTypeXMLMarkup()
         };
 
         return xmlFieldDetail;
@@ -531,7 +533,8 @@ export class XMLMarkupMockService {
         let xmlFieldDetail: XMLFieldDetail = {
             fieldType: "Currency",
             apiName: "Currency__c",
-            fieldLabel: "Currency"
+            fieldLabel: "Currency",
+            xmlMarkup: this.getCurrencyFieldTypeXMLMarkup()
         };
 
         return xmlFieldDetail;
@@ -562,7 +565,8 @@ export class XMLMarkupMockService {
         let xmlFieldDetail: XMLFieldDetail = {
             fieldType: "Checkbox",
             apiName: "Checkbox__c",
-            fieldLabel: "Checkbox"
+            fieldLabel: "Checkbox",
+            xmlMarkup: this.getCheckboxFieldTypeXMLMarkup()
         };
 
         return xmlFieldDetail;
@@ -592,7 +596,8 @@ export class XMLMarkupMockService {
             fieldType: "MultiselectPicklist",
             apiName: "MultiPicklist__c",
             picklistValues: mockedMultiSelectPicklistValues,
-            fieldLabel: "MultiPicklistTest"
+            fieldLabel: "MultiPicklistTest",
+            xmlMarkup: this.getMultiSelectPicklistFieldTypeXMLMarkup()
         };
 
         return multiSelectPicklistXMLField;    
@@ -716,7 +721,8 @@ export class XMLMarkupMockService {
             fieldType: "Picklist",
             apiName: "Picklist__c",
             picklistValues: mockedPicklistValues,
-            fieldLabel: "Picklist"
+            fieldLabel: "Picklist",
+            xmlMarkup: this.getPicklistFieldTypeXMLMarkup()
         };
 
         return picklistXMLField;
@@ -829,7 +835,8 @@ export class XMLMarkupMockService {
         let textXMLFieldDetail: XMLFieldDetail = {
             fieldType: "Text",
             apiName: "Text__c",
-            fieldLabel: "Text"
+            fieldLabel: "Text",
+            xmlMarkup: this.getTextFieldTypeXMLMarkup()
         };
 
         return textXMLFieldDetail;

--- a/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
@@ -659,16 +659,15 @@ export class XMLMarkupMockService {
 
     static getPicklistFieldSetToGlobalPicklistXMLFieldDetail() {
 
-        const dependentPicklistXMLField: XMLFieldDetail = {
+        const globalPicklistXMLField: XMLFieldDetail = {
             fieldType: "Picklist",
             apiName: "ValueSetPicklist",
             globalValueSetName: 'Value_Set_Picklist_VS',
-            picklistValues: [],
             fieldLabel: "Value Set Picklist",
             xmlMarkup: this.getGlobalValueSetXMLMarkup()
         };
 
-        return dependentPicklistXMLField;      
+        return globalPicklistXMLField;      
     }
 
     static getGlobalValueSetXMLMarkup() {
@@ -691,6 +690,19 @@ export class XMLMarkupMockService {
 `;
 
         return xmlMarkup;
+    }
+
+     static getExpectedStandardValueSetLeadSourcePicklistXMLFieldDetail() {
+
+        const standardValueSetPicklistXMLField: XMLFieldDetail = {
+            fieldType: "Picklist",
+            apiName: "LeadSource",
+            isStandardValueSet: true,
+            fieldLabel: "LeadSource",
+            xmlMarkup: this.getStandardValueSetLeadSourceXMLMarkup()
+        };
+
+        return standardValueSetPicklistXMLField;      
     }
 
     static getStandardValueSetLeadSourceXMLMarkup() {

--- a/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
@@ -466,7 +466,7 @@ export class XMLMarkupMockService {
             <value>
                 <fullName>hedges</fullName>
                 <default>false</default>
-                <isActive>hedges</isActive>
+                <isActive>true</isActive>
                 <label>hedges</label>
             </value>
         </valueSetDefinition>
@@ -850,7 +850,7 @@ export class XMLMarkupMockService {
 
     static getPicklistXMLFieldDetail(): XMLFieldDetail {
 
-        const mockedPicklistValues = this.getIPicklistValuesForPickllist__c();
+        const mockedPicklistValues = this.getIPicklistValuesForPicklist__c();
         let picklistXMLField: XMLFieldDetail = {
             fieldType: "Picklist",
             apiName: "Picklist__c",
@@ -863,7 +863,7 @@ export class XMLMarkupMockService {
         
     }
 
-    static getIPicklistValuesForPickllist__c(): IPicklistValue[] {
+    static getIPicklistValuesForPicklist__c(): IPicklistValue[] {
         
         const expectedPicklistFieldDetails:IPicklistValue[] = [
             {
@@ -896,6 +896,8 @@ export class XMLMarkupMockService {
                 label: 'willoughby',
                 default: false
             }
+            
+
         ];
 
         return expectedPicklistFieldDetails;

--- a/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
@@ -9,7 +9,8 @@ export class XMLMarkupMockService {
             fieldType: "MasterDetail",
             apiName: "MD_MegaMapMadness__c",
             fieldLabel: "MD MegaMapMadness",
-            referenceTo: "MegaMapMadness__c"
+            referenceTo: "MegaMapMadness__c",
+            xmlMarkup: this.getMasterDetailFieldTypeXMLMarkup()
         };
 
         return masterDetailXMLField;   
@@ -43,7 +44,8 @@ export class XMLMarkupMockService {
         const urlXMLField: XMLFieldDetail = {
             fieldType: "Url",
             apiName: "Url__c",
-            fieldLabel: "Url"
+            fieldLabel: "Url",
+            xmlMarkup: this.getUrlFieldTypeXMLMarkup()
         };
 
         return urlXMLField;         
@@ -71,7 +73,8 @@ export class XMLMarkupMockService {
         const timeXMLField: XMLFieldDetail = {
             fieldType: "Time",
             apiName: "Time__c",
-            fieldLabel: "Time"
+            fieldLabel: "Time",
+            xmlMarkup: this.getTimeFieldTypeXMLMarkup()
         };
 
         return timeXMLField;     
@@ -100,7 +103,8 @@ export class XMLMarkupMockService {
         const richTextAreaXMLField: XMLFieldDetail = {
             fieldType: "Html",
             apiName: "TextAreaRich__c",
-            fieldLabel: "TextAreaRich"
+            fieldLabel: "TextAreaRich",
+            xmlMarkup: this.getRichTextAreaFieldTypeXMLMarkup()
         };
 
         return richTextAreaXMLField;     
@@ -129,7 +133,8 @@ export class XMLMarkupMockService {
         const longTextAreaXMLField: XMLFieldDetail = {
             fieldType: "LongTextArea",
             apiName: "Text_Area_Long__c",
-            fieldLabel: "Text Area Long"
+            fieldLabel: "Text Area Long",
+            xmlMarkup: this.getLongTextAreaFieldTypeXMLMarkup()
         };
 
         return longTextAreaXMLField;     
@@ -159,7 +164,8 @@ export class XMLMarkupMockService {
         const phoneXMLField: XMLFieldDetail = {
             fieldType: "Phone",
             apiName: "Phone__c",
-            fieldLabel: "Phone"
+            fieldLabel: "Phone",
+            xmlMarkup: this.getPhoneFieldTypeXMLMarkup()
         };
 
         return phoneXMLField;       
@@ -188,7 +194,8 @@ export class XMLMarkupMockService {
         const numberXMLField: XMLFieldDetail = {
             fieldType: "Number",
             apiName: "Number__c",
-            fieldLabel: "Number"
+            fieldLabel: "Number",
+            xmlMarkup: this.getNumberFieldTypeXMLMarkup()
         };
 
         return numberXMLField;    
@@ -217,7 +224,8 @@ export class XMLMarkupMockService {
         const locationXMLField: XMLFieldDetail = {
             fieldType: "Location",
             apiName: "Geolocation__c",
-            fieldLabel: "Geolocation"
+            fieldLabel: "Geolocation",
+            xmlMarkup: this.getGeolocationFieldTypeXMLMarkup()
         };
 
         return locationXMLField;
@@ -246,7 +254,8 @@ export class XMLMarkupMockService {
         const formulaXMLField: XMLFieldDetail = {
             fieldType: "Number",
             apiName: "Formula__c",
-            fieldLabel: "Formula"
+            fieldLabel: "Formula",
+            xmlMarkup: this.getFormulaFieldTypeXMLMarkup()
         };
 
         return formulaXMLField;      
@@ -280,7 +289,8 @@ export class XMLMarkupMockService {
             fieldType: "Lookup",
             apiName: "Example_Everything_Lookup__c",
             fieldLabel: "Example Everything Lookup",
-            referenceTo: "Example_Everything__c"
+            referenceTo: "Example_Everything__c",
+            xmlMarkup: this.getLookupFieldTypeXMLMarkup()
         };
 
         return lookupXMLField;        
@@ -315,7 +325,8 @@ export class XMLMarkupMockService {
             apiName: "DependentPicklist__c",
             picklistValues: mockedMultiSelectPicklistValues,
             fieldLabel: "DependentPicklist",
-            controllingField: "Picklist__c"
+            controllingField: "Picklist__c",
+            xmlMarkup: this.getDependentPicklistFieldTypeXMLMarkup()
         };
 
         return dependentPicklistXMLField;      
@@ -446,7 +457,8 @@ export class XMLMarkupMockService {
         let xmlFieldDetail: XMLFieldDetail = {
             fieldType: "Email",
             apiName: "Email__c",
-            fieldLabel: "Email"
+            fieldLabel: "Email",
+            xmlMarkup: this.getEmailFieldTypeXMLMarkup()
         };
 
         return xmlFieldDetail;    

--- a/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
@@ -412,44 +412,166 @@ export class XMLMarkupMockService {
     
     }
 
+    static getDependentPicklistFieldTypeWithIsActiveTagsXMLMarkup() {
+        const xmlMarkup = `
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DependentPicklist__c</fullName>
+    <label>DependentPicklist</label>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <controllingField>Picklist__c</controllingField>
+        <restricted>true</restricted>
+        <valueSetDefinition>
+            <sorted>false</sorted>
+            <value>
+                <fullName>tree</fullName>
+                <default>false</default>
+                <label>tree</label>
+            </value>
+            <value>
+                <fullName>plant</fullName>
+                <default>false</default>
+                <label>plant</label>
+            </value>
+            <value>
+                <fullName>fancystone</fullName>
+                <default>false</default>
+                <isActive>hedges</isActive>
+                <label>fancystone</label>
+            </value>
+            <value>
+                <fullName>weed</fullName>
+                <default>false</default>
+                <label>weed</label>
+            </value>
+            <value>
+                <fullName>mulch</fullName>
+                <default>false</default>
+                <label>mulch</label>
+            </value>
+            <value>
+                <fullName>rocks</fullName>
+                <default>false</default>
+                <label>rocks</label>
+            </value>
+            <value>
+                <fullName>moss</fullName>
+                <default>false</default>
+                <isActive>false</isActive>
+                <label>moss</label>
+            </value>
+            <value>
+                <fullName>hedges</fullName>
+                <default>false</default>
+                <isActive>hedges</isActive>
+                <label>hedges</label>
+            </value>
+        </valueSetDefinition>
+        <valueSettings>
+            <controllingFieldValue>cle</controllingFieldValue>
+            <controllingFieldValue>eastlake</controllingFieldValue>
+            <controllingFieldValue>madison</controllingFieldValue>
+            <controllingFieldValue>willoughby</controllingFieldValue>
+            <valueName>tree</valueName>
+        </valueSettings>
+        <valueSettings>
+            <controllingFieldValue>cle</controllingFieldValue>
+            <controllingFieldValue>eastlake</controllingFieldValue>
+            <controllingFieldValue>madison</controllingFieldValue>
+            <controllingFieldValue>mentor</controllingFieldValue>
+            <controllingFieldValue>wickliffe</controllingFieldValue>
+            <controllingFieldValue>willoughby</controllingFieldValue>
+            <valueName>weed</valueName>
+        </valueSettings>
+        <valueSettings>
+            <controllingFieldValue>cle</controllingFieldValue>
+            <controllingFieldValue>eastlake</controllingFieldValue>
+            <controllingFieldValue>willoughby</controllingFieldValue>
+            <valueName>mulch</valueName>
+        </valueSettings>
+        <valueSettings>
+            <controllingFieldValue>cle</controllingFieldValue>
+            <controllingFieldValue>wickliffe</controllingFieldValue>
+            <valueName>rocks</valueName>
+        </valueSettings>
+        <valueSettings>
+            <controllingFieldValue>madison</controllingFieldValue>
+            <controllingFieldValue>mentor</controllingFieldValue>
+            <valueName>plant</valueName>
+        </valueSettings>
+    </valueSet>
+</CustomField>
+`;
+
+        return xmlMarkup;   
+    
+    }
+
+   
+
     static getIPicklistValuesForDependentPickllist__c(): IPicklistValue[] {
         
         const expectedPicklistFieldDetails:IPicklistValue[] = [
             {
-                fullName: 'tree',
+                picklistOptionApiName: 'tree',
                 label: 'tree',
                 default: false,
-                availableForControllingValues: ['cle', 'eastlake', 'madison', 'willoughby']
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'willoughby']
             },
             {
-                fullName: 'plant',
+                picklistOptionApiName: 'plant',
                 label: 'plant',
                 default: false,
-                availableForControllingValues: ['madison', 'mentor']
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['madison', 'mentor']
             },
             {
-                fullName: 'weed',
+                picklistOptionApiName: 'weed',
                 label: 'weed',
                 default: false,
-                availableForControllingValues: ['cle', 'eastlake', 'madison', 'mentor', 'wickliffe', 'willoughby']
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'madison', 'mentor', 'wickliffe', 'willoughby']
             },
             {
-                fullName: 'mulch',
+                picklistOptionApiName: 'mulch',
                 label: 'mulch',
                 default: false,
-                availableForControllingValues: ['cle', 'eastlake', 'willoughby']
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle', 'eastlake', 'willoughby']
             },
             {
-                fullName: 'rocks',
+                picklistOptionApiName: 'rocks',
                 label: 'rocks',
                 default: false,
-                availableForControllingValues: ['cle',  'wickliffe']
+                controllingValuesFromParentPicklistThatMakeThisValueAvailableAsASelection: ['cle',  'wickliffe']
             }
        
         ];
 
         return expectedPicklistFieldDetails;
     
+    }
+
+    static getGlobalValueSetXMLMarkup() {
+
+        const xmlMarkup = `                     
+        <?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ValueSetPicklist</fullName>
+    <label>Value Set Picklist</label>
+    <required>false</required>
+    <trackFeedHistory>false</trackFeedHistory>
+    <trackHistory>false</trackHistory>
+    <trackTrending>false</trackTrending>
+    <type>Picklist</type>
+    <valueSet>
+        <restricted>true</restricted>
+        <valueSetName>Value_Set_Picklist_VS</valueSetName>
+    </valueSet>
+</CustomField>
+`;
+
+        return xmlMarkup;
     }
 
     static getEmailXMLFieldDetail() {
@@ -745,32 +867,32 @@ export class XMLMarkupMockService {
         
         const expectedPicklistFieldDetails:IPicklistValue[] = [
             {
-                fullName: 'cle',
+                picklistOptionApiName: 'cle',
                 label: 'cle',
                 default: false
             },
             {
-                fullName: 'eastlake',
+                picklistOptionApiName: 'eastlake',
                 label: 'eastlake',
                 default: false
             },
             {
-                fullName: 'madison',
+                picklistOptionApiName: 'madison',
                 label: 'madison',
                 default: false
             },
             {
-                fullName: 'mentor',
+                picklistOptionApiName: 'mentor',
                 label: 'mentor',
                 default: false
             },
             {
-                fullName: 'wickliffe',
+                picklistOptionApiName: 'wickliffe',
                 label: 'wickliffe',
                 default: false
             },
             {
-                fullName: 'willoughby',
+                picklistOptionApiName: 'willoughby',
                 label: 'willoughby',
                 default: false
             }
@@ -784,37 +906,37 @@ export class XMLMarkupMockService {
         
         const expectedPicklistFieldDetails:IPicklistValue[] = [
             {
-                fullName: 'chicken',
+                picklistOptionApiName: 'chicken',
                 label: 'chicken',
                 default: false
             },
             {
-                fullName: 'chorizo',
+                picklistOptionApiName: 'chorizo',
                 label: 'chorizo',
                 default: false
             },
             {
-                fullName: 'egg',
+                picklistOptionApiName: 'egg',
                 label: 'egg',
                 default: false
             },
             {
-                fullName: 'fish',
+                picklistOptionApiName: 'fish',
                 label: 'fish',
                 default: false
             },
             {
-                fullName: 'pork',
+                picklistOptionApiName: 'pork',
                 label: 'pork',
                 default: false
             },
             {
-                fullName: 'steak',
+                picklistOptionApiName: 'steak',
                 label: 'steak',
                 default: false
             },
             {
-                fullName: 'tofu',
+                picklistOptionApiName: 'tofu',
                 label: 'tofu',
                 default: false
             }


### PR DESCRIPTION
### Motivation and Context

When generating recipes error handling was not granular and provided no specific detail into what Salesforce field in the local project base was causing an issue. This functionality wraps the field processing service in a try/catch and generates a error details page for self-service troubleshooting.

BUGFIX - as part of this work, there was a bug discovered for dependent picklists and global picklist markup.  This update provides functionality that provides necessary logic to prevent recipe generation failure at run time.

### What does this PR do?

- introduce try/catch at field processing level to provide error message and generate file capturing error details around what field caused faker generation to fail
- for faker-js -> adjust "text" type function to trim lorem ipsum generator to 255 characters
- new IRecipeService interface methods for providing correct syntax for picklist or multipicklist for global value set fields
- new properties on XMLFieldDetail for capturing info whether field is globalvaluepicklist or standard value set
- bugfix: prevent issues where picklist have values for inactive fields or dependent picklists that do not have a configuration for a parent picklist value ( done by providing "if size > 0" check) 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):


### How Has This Been Tested?
- [ ] Tested on Windows
- [x] Tested on macOS
- [ ] Tested on Linux
- [x] Added new unit tests
- [x] Updated existing tests

#### Test Details

Built additional mock structures to handle edge scenarios for standardpicklists, global value picklist and dependent picklists with isactive set to false

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


***

# Changelog for branch: feature/fieldProcessorErrorHandling

Generated on: 2025-05-16

## Summary
- Total commits: 23
- Files added: 1
- Files modified: 23
- Files deleted: 0
- Files renamed: 0

*** 

## Changes at a glance
## Added Files
| Added File | Commits | History |
|------|---------|---------|
| src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/fields/GlobalValuePicklist__c.field-meta.xml | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/fields/GlobalValuePicklist__c.field-meta.xml) |
## Modified Files
| Modified File | Commits | History |
|------|---------|---------|
| extensionDevelopmentScriptsAndArtifacts/treecipe/GeneratedRecipes/recipe-2025-01-03T15-45-06-fakerjs.yaml | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/extensionDevelopmentScriptsAndArtifacts/treecipe/GeneratedRecipes/recipe-2025-01-03T15-45-06-fakerjs.yaml) |
| src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts) |
| src/treecipe/src/DirectoryProcessingService/tests/DirectoryProcessor.test.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/DirectoryProcessingService/tests/DirectoryProcessor.test.ts) |
| src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/recordTypes/OneRecType.recordType-meta.xml | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/recordTypes/OneRecType.recordType-meta.xml) |
| src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/recordTypes/TwoRecType.recordType-meta.xml | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockObjectsDirectory/objects/Example_Everything__c/recordTypes/TwoRecType.recordType-meta.xml) |
| src/treecipe/src/ErrorHandlingService/ErrorHandlingService.ts | 4 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/ErrorHandlingService/ErrorHandlingService.ts) |
| src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts | 3 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts) |
| src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts | 2 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts) |
| src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/SnowfakeryRecipeProcessor.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/SnowfakeryRecipeProcessor.ts) |
| src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/tests/SnowfakeryRecipeProcessor.test.ts | 2 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/tests/SnowfakeryRecipeProcessor.test.ts) |
| src/treecipe/src/ObjectInfoWrapper/FieldInfo.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/ObjectInfoWrapper/FieldInfo.ts) |
| src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts | 2 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts) |
| src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/tests/FakerJSRecipeFakerService.test.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/tests/FakerJSRecipeFakerService.test.ts) |
| src/treecipe/src/RecipeFakerService.ts/IRecipeFakerService.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/RecipeFakerService.ts/IRecipeFakerService.ts) |
| src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts) |
| src/treecipe/src/RecipeService/RecipeService.ts | 4 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/RecipeService/RecipeService.ts) |
| src/treecipe/src/RecipeService/tests/RecipeService.test.ts | 2 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/RecipeService/tests/RecipeService.test.ts) |
| src/treecipe/src/RecordTypeService/tests/RecordTypeService.test.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/RecordTypeService/tests/RecordTypeService.test.ts) |
| src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts | 2 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts) |
| src/treecipe/src/XMLProcessingService/XMLFieldDetail.ts | 3 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/XMLProcessingService/XMLFieldDetail.ts) |
| src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts | 6 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts) |
| src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts | 6 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/XMLProcessingService/tests/XmlFileProcessor.test.ts) |
| src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts | 7 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/fieldProcessorErrorHandling/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts) |

