### PR TITLE
Feature/faker js variable expression syntax

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 ### Motivation and Context
 [Why is this change required? What problem does it solve? If it fixes an open issue, please link to the issue here]
 
-### What does this PR do?
-[Provide a clear and concise description of the changes in this PR]
+### Any Technical Decisions to Note??
+[Are there any adjustments or introductions, beyond simple, that enables this functionality or could even introduce challenges going forward]
 
 
 ### Type of Change

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,8 +31,5 @@
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 
-### Additional Notes
-[Add any other context, screenshots, or relevant information about the PR here]
-
 ### Reviewers
 @mention-team-members-or-specific-reviewers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Change Log
 
+## [2.2.0] [PR#25](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/26) - Feature : 2.2.0
+
+Feature: Variable syntax capabilities using faker-js recipes
+
+A great feature to snowfakery is [leveraging variable definitions](https://snowfakery.readthedocs.io/en/latest/index.html#define-variables). When generating fake data is the ability to reuse previously generated values, constants or hardcoded variable names. With this update, faker-js based recipes can leverage variable syntax as well.
+
+This functionality introduces a way for specific variable syntax to be leveraged in fake data recipe generation.
+
+'''yaml
+
+- var: dinoName 
+  value: "indominous"
+
+- var: animatedHero 
+  value: batman
+
+- var: randomDate
+  value: |
+    ${{ faker.date.between({ from: new Date('2023-01-01'), to: new Date('2023-02-01') }).toISOString().split('T')[0] }}
+
+- var: multipicklistFood
+  value: ${{ (faker.helpers.arrayElements(['chorizo','pork','steak','tofu'])).join(';') }} 
+
+- object: Account
+  count: 1
+  nickname: AccountWithCustomFieldsSetByVariables
+  fields:
+    VarDate__c: ${{ var.randomDate }}    
+    VarAnimatedHero__c: ${{ var.animatedHero }}
+    VarDinoName__c: ${{ var.dinoName }} 
+    VarFood__c: ${{ var.multipicklistFood }}
+
+'''
+
 ## [2.1.0] [PR#25](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/25) - Feature and Bug Fix: 2.1.0
 
 When generating recipes error handling was not granular and provided no specific detail into what Salesforce field in the local project base was causing an issue. This functionality wraps the field processing service in a try/catch and generates a error details page for self-service troubleshooting.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 # Salesforce-Data-Treecipe
 
-**Salesforce-Data-Treecipe** is a Visual Studio Code extension designed to streamline the process of generating production-like data during development in order to support building Quality in. This extension auto-generates a recipe yaml file based on what is already in the source object metadata xml of your project.
+**Salesforce-Data-Treecipe** is a Visual Studio Code extension designed to streamline the process of generating production-like data during development in order to support building Quality in. 
+
+This extension auto-generates a recipe yaml file based on the running, local project structure. Said differently, what is already in the "source" for the project.
+
+From the generated "Fake-Data Generating YAML Files", additional commands can be used following the recipe generation to build Collections API datasets that can be committed and reused as needed.
+
+Users have two choices of "Fake Data" implentations:
+
+[faker-js](https://fakerjs.dev/) - Can handle simple to complicated data generation and uploads
+[snowfakery](https://snowfakery.readthedocs.io/en/latest/) - All of the above and way more for adnvanced data generation scenarios
 
 ---
 
-## Optional Prerequisites for using [snowfakery](https://snowfakery.readthedocs.io/en/latest/) as Faker service instead of [faker-js](https://fakerjs.dev/). 
+## Prerequisites for Snowfakery
+
+### If using [snowfakery](https://snowfakery.readthedocs.io/en/latest/) as Faker service instead of [faker-js](https://fakerjs.dev/). 
 
 "faker-js" can be natively installed with VS Code extensions and does not require machine setup steps.
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,7 @@ Users have two choices of "Fake Data" implementations:
 
 ## Table of Contents
 
-- [Salesforce-Data-Treecipe](#salesforce-data-treecipe)
-  - [Table of Contents](#table-of-contents)
   - [Prerequisites for Snowfakery](#prerequisites-for-snowfakery)
-    - [If using snowfakery as Faker service instead of faker-js.](#if-using-snowfakery-as-faker-service-instead-of-faker-js)
   - [VS Code Extension Installation](#vs-code-extension-installation)
   - ["How To" YouTube Walkthroughs:](#how-to-youtube-walkthroughs)
   - [Get started by walking through the below commands](#get-started-by-walking-through-the-below-commands)

--- a/README.md
+++ b/README.md
@@ -1,26 +1,64 @@
 # Salesforce-Data-Treecipe
 
-**Salesforce-Data-Treecipe** is a Visual Studio Code extension designed to streamline the process of generating production-like data during development in order to support building Quality in. 
+**Salesforce-Data-Treecipe** is a Visual Studio Code extension designed to streamline the process of generating production-like data during development in order to support building Quality in.
 
 This extension auto-generates a recipe yaml file based on the running, local project structure. Said differently, what is already in the "source" for the project.
 
 From the generated "Fake-Data Generating YAML Files", additional commands can be used following the recipe generation to build Collections API datasets that can be committed and reused as needed.
 
-Users have two choices of "Fake Data" implentations:
+Users have two choices of "Fake Data" implementations:
 
-[faker-js](https://fakerjs.dev/) - Can handle simple to complicated data generation and uploads
-[snowfakery](https://snowfakery.readthedocs.io/en/latest/) - All of the above and way more for adnvanced data generation scenarios
+* [faker-js](https://fakerjs.dev/) - Can handle simple to complicated data generation and uploads
+* [snowfakery](https://snowfakery.readthedocs.io/en/latest/) - All of the above and way more for advanced data generation scenarios
+
+---
+
+## Table of Contents
+
+- [Salesforce-Data-Treecipe](#salesforce-data-treecipe)
+  - [Table of Contents](#table-of-contents)
+  - [Prerequisites for Snowfakery](#prerequisites-for-snowfakery)
+    - [If using snowfakery as Faker service instead of faker-js.](#if-using-snowfakery-as-faker-service-instead-of-faker-js)
+  - [VS Code Extension Installation](#vs-code-extension-installation)
+  - ["How To" YouTube Walkthroughs:](#how-to-youtube-walkthroughs)
+  - [Get started by walking through the below commands](#get-started-by-walking-through-the-below-commands)
+    - [1. **Salesforce Treecipe: Initiate Configuration File**](#1-salesforce-treecipe-initiate-configuration-file)
+      - [How It Works:](#how-it-works)
+      - [Corresponding Video:](#corresponding-video)
+    - [2. **Salesforce Treecipe: Generate Treecipe**](#2-salesforce-treecipe-generate-treecipe)
+      - [Prerequisite:](#prerequisite)
+      - [Corresponding Video:](#corresponding-video-1)
+    - [3. **Salesforce Treecipe: Run Faker by Recipe**](#3-salesforce-treecipe-run-faker-by-recipe)
+      - [Corresponding Video:](#corresponding-video-2)
+    - [4. **Salesforce Treecipe: Insert Data Set by Directory**](#4-salesforce-treecipe-insert-data-set-by-directory)
+  - [VIDEO WALKTHROUGHS](#video-walkthroughs)
+      - [Initiate Treecipe Configuration with expected Objects directory](#initiate-treecipe-configuration-with-expected-objects-directory)
+      - [Generate Treecipe based on treecipe.config.jcon (keep an eye out for OOTB fields and "REMOVE ME" lines)](#generate-treecipe-based-on-treecipeconfigjcon-keep-an-eye-out-for-ootb-fields-and-remove-me-lines)
+      - [Run Snowfakery by existing recipe yaml file](#run-snowfakery-by-existing-recipe-yaml-file)
+      - [Insert Data Set by Directory](#insert-data-set-by-directory)
+  - [Troubleshooting, Exception Handling, and Reporting Bugs](#troubleshooting-exception-handling-and-reporting-bugs)
+      - [Video Walkthrough:](#video-walkthrough)
+  - [Contributing](#contributing)
+  - [License](#license)
+  - [Install Snowfakery CLI](#install-snowfakery-cli)
+    - [Snowfakery CLI Installation and Usage](#snowfakery-cli-installation-and-usage)
+      - [Overview](#overview)
+      - [Prerequisites](#prerequisites)
+      - [Installation](#installation)
+      - [Verify the Installation](#verify-the-installation)
+      - [Usage (Without Salesforce Data Treecipe Extension)](#usage-without-salesforce-data-treecipe-extension)
+      - [Uninstalling Snowfakery](#uninstalling-snowfakery)
 
 ---
 
 ## Prerequisites for Snowfakery
 
-### If using [snowfakery](https://snowfakery.readthedocs.io/en/latest/) as Faker service instead of [faker-js](https://fakerjs.dev/). 
+### If using [snowfakery](https://snowfakery.readthedocs.io/en/latest/) as Faker service instead of [faker-js](https://fakerjs.dev/).
 
 "faker-js" can be natively installed with VS Code extensions and does not require machine setup steps.
 
-1. [Install Snowfakery CLI](#install-snowfakery) 
-   
+1. [Install Snowfakery CLI](#install-snowfakery)
+
 ---
 
 ## VS Code Extension Installation
@@ -31,36 +69,36 @@ Users have two choices of "Fake Data" implentations:
 
 ---
 
-## "How To" YouTube Walkthroughs: 
+## "How To" YouTube Walkthroughs:
 
-- [Salesforce Data Treecipe Initiation, Setup, and Simple Account and Contact Example in VS Code:](https://youtu.be/xCB7vcB4nqM?si=e3N2HmtI2Ca-U7m3)
+* [Salesforce Data Treecipe Initiation, Setup, and Simple Account and Contact Example in VS Code:](https://youtu.be/xCB7vcB4nqM?si=e3N2HmtI2Ca-U7m3)
 
 ---
 
-## Get started by walking through the below commands (see corresponding video for each step):
+## Get started by walking through the below commands
 
 Note: press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS) to open the Command Palette.
 
-1. [Initiate Configuration File](#command1)
-2. [Generate Treecipe](#command2)
-3. [Run Snowfakery by Recipe(Treecipe) to create FakeDataSet](#command3)
-4. [Insert Data Set by Directory ](#command4)
+1. [Initiate Configuration File](#1-salesforce-treecipe-initiate-configuration-file)
+2. [Generate Treecipe](#2-salesforce-treecipe-generate-treecipe)
+3. [Run Snowfakery by Recipe(Treecipe) to create FakeDataSet](#3-salesforce-treecipe-run-faker-by-recipe)
+4. [Insert Data Set by Directory](#4-salesforce-treecipe-insert-data-set-by-directory)
 
 ---
 
+### <a name="1-salesforce-treecipe-initiate-configuration-file"></a>1. **Salesforce Treecipe: Initiate Configuration File**
 
- ### <a name="command1"></a> 1. **Salesforce Treecipe: Initiate Configuration File**
- 
 This [command initiates the creation of a configuration file](https://github.com/jdschleicher/Salesforce-Data-Treecipe/tree/main#initiate-treecipe-configuration-with-expected-objects-directory) that is required before using other features of the extension.
 
-The command creates a root directory folder called "treecipe" and within it a configuration file called "treecipe.config.json". 
+The command creates a root directory folder called "treecipe" and within it a configuration file called "treecipe.config.json".
 
 This file is auto generated based on the field configurations detailed selection made when prompted "Select objects directory".
 
 The end result treecipe.config.json file is expected to look like the below:
 
-- **salesforceObjectsPath** - will vary based on selected directory in your VS Code workspace
-- **dataFakerService** - can be 'snowfakery' or 'faker-js'
+* **salesforceObjectsPath** - will vary based on selected directory in your VS Code workspace
+* **dataFakerService** - can be 'snowfakery' or 'faker-js'
+
 ```json
 {
     "salesforceObjectsPath": "./force-app/main/default/objects/",
@@ -70,141 +108,111 @@ The end result treecipe.config.json file is expected to look like the below:
 
 #### How It Works:
 
-- Select **"Salesforce Treecipe: Initiate Configuration File"** from the command palette.
-- You will be prompted to type the **source directory** in your codebase where Salesforce objects are stored in source format. Begin typing the folder and the directories will auto-filter to match directories based on the entered text.
+* Select **"Salesforce Treecipe: Initiate Configuration File"** from the command palette.
+* You will be prompted to type the **source directory** in your codebase where Salesforce objects are stored in source format. Begin typing the folder and the directories will auto-filter to match directories based on the entered text.
 
 Once the configuration file is generated, you can begin using the **Generate Treecipe** command.
 
-
 #### Corresponding Video:
 
-https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#initiate-treecipe-configuration-with-expected-objects-directory
+[https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#initiate-treecipe-configuration-with-expected-objects-directory](https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#initiate-treecipe-configuration-with-expected-objects-directory)
 
 ---
 
-### 2.<a name="command2"></a> **Salesforce Treecipe: Generate Treecipe**
+### <a name="2-salesforce-treecipe-generate-treecipe"></a>2. **Salesforce Treecipe: Generate Treecipe**
+
 This command [generates a **Treecipe**](https://github.com/jdschleicher/Salesforce-Data-Treecipe/tree/main#generate-treecipe-based-on-treecipeconfigjcon--keep-an-eye-out-for-ootb-fields-and-remove-me-lines-), a structured representation of your Salesforce data, based on your treecipe configuration and the objects directory it is pointed to.
 
 It parses the "salesforceObjectsPath" directory path that was provided when running the "Initiate Configuration File" command above, and then generates a yaml file of objects and associated fields found in that directory.
 
 As part of this yaml file generation there are some items to be aware of:
-- **"TODO" items:** Because this tool can only make decisions based upon what's found in the metadata and markjup, similiar to LLM tools, it requires a "Person in the Middle" to review sections of the yaml where a comment labled "TODO" is found. Before generating a fake data set from an expected yaml file, that yaml file should be reviewed for "TODO" items and have each TODO cleared based on the message. Sometimes the "TODO" message is to confirm that a field that was added to the yaml file did not have xml markup and is an OOTB field. Other times the "TODO" is needed to select which record type values to choose for a picklist field. There could be several record types for an object and generating data for that object requires choosing what associated record type choices to populate for the fake data set.
-- **Handling of field files without xml markup:** For OOTB fields like AccountNumber or Name on the Account object, there is not detailed XML markup found in their field files. These occurrences are marked with a "TODO" item because they need to be either cleared or provided a faker value. For example, AccountNumber is an auto-generated field and doesn't need a faker value. However Account "Name" field will need a faker value, "${{ fake.company }}". In upcoming releases, there will be an auto mapper that handles OOTB objects and fields but for now requires a set of eyes to review the OOTB updates.
-- **Record Type Picklist, Dependent Picklist, Multiselect Picklist Selections:** At the start of the yaml file generation for an object found in the project source, an expected structure is parsed in order to confirm if there are different Record Types associated with the object. Within the objects folder that allows the yaml generation logic to parse the "recordTypes" directory and provide picklist faker options based on each record type:
 
-**NOTE:** 
-
-If this command is ran before "Initiate Configuration File" command, an exception will be handled and you a VSCode warning box will render showing an option to run the "Initiate Configuration File" command. 
-
-There is also an option to "Report a Bug" if the initiation command has already been completed.
-
-#### Prerequisite:
-- **Generate Treecipe** will **not** work until you have completed the configuration step and selected a **Salesforce objects directory**.
-- If the configuration file is missing or incomplete, you will be prompted to initiate the configuration first.
-
-Once your configuration file and objects directory are set up, running this command will generate a custom tree structure to assist in your Salesforce development and data handling.
-
-
-#### Corresponding Video:
-
-https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#generate-treecipe-based-on-treecipeconfigjcon--keep-an-eye-out-for-ootb-fields-and-remove-me-lines-
-
----
-
- ### <a name="command3"></a> 3. **Salesforce Treecipe: Run Faker by Recipe**
- 
-This command [prompts the user to select an existing recipe(Treecipe) file](https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#run-snowfakery-by-existing-recipe-yaml-file) to generate fake data from.
-
-With the selection made, the snowfakery CLI will execute against they yaml file and produce json structured, production-like data which is then converted for usage with Salesforce [Collection Api](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_create.htm)
-
-#### Corresponding Video:
-
-https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#run-snowfakery-by-existing-recipe-yaml-file
-
----
-
- ### <a name="command4"></a> 4. **Salesforce Treecipe: Insert Data Set by Directory**
- 
-This command prompts the user for the following items:
-1. Select a pre-existing "dataset" directory with expected Collections-Api structure files
-2. Enter name of already locally authenticated Salesforce alis (DO NOT USE PRODUCTION ORG!!!)
-3. Select "ALL OR NONE" option. 
-   1. "false" will not perform any roll back and keep any successfully inserted records as is
-   2. "true" will roll back all inserted records
-
-
-
----
-
-### VIDEO WALKTHROUGHS:
-
-#### Initiate Treecipe Configuration with expected Objects directory
-
-
-https://github.com/user-attachments/assets/f8401f28-a04c-4abc-a56f-c860cce96dee
-
-
----
-
-#### Generate Treecipe based on treecipe.config.jcon ( keep an eye out for OOTB fields and "REMOVE ME" lines )
-
-
-https://github.com/user-attachments/assets/fd127b55-d434-4a73-9d65-cf4172fbce6f
-
-
----
-
-#### Run Snowfakery by existing recipe yaml file
-
-
-https://github.com/user-attachments/assets/d7dfcf70-70f8-4ce3-b254-280e2bbb0b7d
-
-
-
----
-
-#### Insert Data Set by Directory
-
-
-
-
-https://github.com/user-attachments/assets/a0491f86-9360-4450-afae-f71fe07dbc21
-
-
-
-
----
-
-
-## Troubleshooting, Exception Handling, and Reporting Bugs
-
-
-See below for troubleshooting when specific commands are not working:
-
-- "**Salesforce Treecipe - Generate Treecipe - generateRecipeFromConfigurationDetail**": 
-  - Ensure that you’ve successfully run **Initiate Configuration File** and selected a valid Salesforce objects directory. The **Generate Treecipe** command depends on the configuration file being present and properly set up.
-  - Ensure the captured objects path in the **treecipe.config.json** has forward-slashes. In windows machines the path can be generated with double back-slashes and would need to be replaced with one forward-slash
-  - Ensure the "defaultFakerService" property in the **treecipe.config.json** is set to "snowfakery"
-  
-- "**Salesforce Treecipe: Initiate Configuration File - initiateTreecipeConfigurationSetup**": 
-  - Ensure an expected project directory was selected when prompted
+* **"TODO" items:** Review sections marked with "TODO" before generating fake data. These mark areas that need clarification or input.
+* **Handling of field files without xml markup:** OOTB fields (e.g., AccountNumber, Name) lack XML detail. Some (like Name) need faker values manually added.
+* **Record Type Picklist, Dependent Picklist, Multiselect Picklist Selections:** Object folders are parsed to detect record types and relevant picklist faker options.
 
 **NOTE:**
 
-All extension commands are wrapped in a try-catch and will prompt a "Report a Bug" that will auto-generate a GitHub Issue template for a bug that includes the stack trace. This would support quick turn-around time for known issues. 
+If this command is run before "Initiate Configuration File" is completed, a warning will appear in VS Code prompting to run it.
 
-See below for a video walkthough:
+#### Prerequisite:
 
+* **Generate Treecipe** requires a valid configuration file and selected Salesforce objects directory.
 
+#### Corresponding Video:
 
-
-https://github.com/user-attachments/assets/dff4a3cb-e244-4959-9dec-dcf094f713c2
-
-
-
+[https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#generate-treecipe-based-on-treecipeconfigjcon--keep-an-eye-out-for-ootb-fields-and-remove-me-lines-](https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#generate-treecipe-based-on-treecipeconfigjcon--keep-an-eye-out-for-ootb-fields-and-remove-me-lines-)
 
 ---
 
+### <a name="3-salesforce-treecipe-run-faker-by-recipe"></a>3. **Salesforce Treecipe: Run Faker by Recipe**
+
+This command [prompts the user to select an existing recipe(Treecipe) file](https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#run-snowfakery-by-existing-recipe-yaml-file) to generate fake data from.
+
+With the selection made, the snowfakery CLI will execute against the yaml file and produce json structured, production-like data which is then converted for usage with Salesforce [Collection Api](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobjects_collections_create.htm)
+
+#### Corresponding Video:
+
+[https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#run-snowfakery-by-existing-recipe-yaml-file](https://github.com/jdschleicher/Salesforce-Data-Treecipe/blob/main/README.md#run-snowfakery-by-existing-recipe-yaml-file)
+
+---
+
+### <a name="4-salesforce-treecipe-insert-data-set-by-directory"></a>4. **Salesforce Treecipe: Insert Data Set by Directory**
+
+This command prompts the user for the following items:
+
+1. Select a pre-existing "dataset" directory with expected Collections-Api structure files
+2. Enter name of already locally authenticated Salesforce alias (**DO NOT USE PRODUCTION ORG!!!**)
+3. Select "ALL OR NONE" option.
+
+   * "false" keeps successfully inserted records
+   * "true" rolls back all inserted records
+
+---
+
+## VIDEO WALKTHROUGHS
+
+#### Initiate Treecipe Configuration with expected Objects directory
+
+[https://github.com/user-attachments/assets/f8401f28-a04c-4abc-a56f-c860cce96dee](https://github.com/user-attachments/assets/f8401f28-a04c-4abc-a56f-c860cce96dee)
+
+#### Generate Treecipe based on treecipe.config.jcon (keep an eye out for OOTB fields and "REMOVE ME" lines)
+
+[https://github.com/user-attachments/assets/fd127b55-d434-4a73-9d65-cf4172fbce6f](https://github.com/user-attachments/assets/fd127b55-d434-4a73-9d65-cf4172fbce6f)
+
+#### Run Snowfakery by existing recipe yaml file
+
+[https://github.com/user-attachments/assets/d7dfcf70-70f8-4ce3-b254-280e2bbb0b7d](https://github.com/user-attachments/assets/d7dfcf70-70f8-4ce3-b254-280e2bbb0b7d)
+
+#### Insert Data Set by Directory
+
+[https://github.com/user-attachments/assets/a0491f86-9360-4450-afae-f71fe07dbc21](https://github.com/user-attachments/assets/a0491f86-9360-4450-afae-f71fe07dbc21)
+
+---
+
+## Troubleshooting, Exception Handling, and Reporting Bugs
+
+See below for troubleshooting when specific commands are not working:
+
+* **Salesforce Treecipe - Generate Treecipe - generateRecipeFromConfigurationDetail:**
+
+  * Ensure "Initiate Configuration File" was successfully run
+  * Ensure path in treecipe.config.json uses forward-slashes
+  * Ensure "defaultFakerService" is set to "snowfakery"
+
+* **Salesforce Treecipe: Initiate Configuration File - initiateTreecipeConfigurationSetup:**
+
+  * Ensure expected project directory was selected
+
+**NOTE:**
+
+All commands are wrapped in try-catch and will prompt a "Report a Bug" dialog. This generates a GitHub Issue template with a stack trace.
+
+#### Video Walkthrough:
+
+[https://github.com/user-attachments/assets/dff4a3cb-e244-4959-9dec-dcf094f713c2](https://github.com/user-attachments/assets/dff4a3cb-e244-4959-9dec-dcf094f713c2)
+
+---
 
 ## Contributing
 
@@ -218,10 +226,9 @@ This extension is licensed under the [MIT License](LICENSE).
 
 ---
 
-### <a name="install-snowfakery"></a> Install Snowfakery CLI
+## <a name="install-snowfakery-cli"></a>Install Snowfakery CLI
 
-
-#### Snowfakery CLI Installation and Usage
+### Snowfakery CLI Installation and Usage
 
 #### Overview
 
@@ -229,54 +236,40 @@ Snowfakery is a tool for generating synthetic data. This document provides instr
 
 #### Prerequisites
 
-- **Python 3.8+** is required. You can verify your Python version by running:
-  
+* **Python 3.8+** is required:
+
   ```bash
   python --version
   ```
 
-  If you need to install or upgrade Python, you can download the latest version from the official Python website:  
-  [https://www.python.org/downloads/](https://www.python.org/downloads/).
+  [https://www.python.org/downloads/](https://www.python.org/downloads/)
 
-- **pip** (Python package manager) should also be installed. You can follow the installation instructions here:  
-  [https://pip.pypa.io/en/stable/installation/](https://pip.pypa.io/en/stable/installation/).
+* **pip** (Python package manager):
+  [https://pip.pypa.io/en/stable/installation/](https://pip.pypa.io/en/stable/installation/)
 
 #### Installation
-
-##### 1. Install Snowfakery via pip
-
-To install Snowfakery globally, open your terminal or command prompt and run the following command:
 
 ```bash
 pip install snowfakery
 ```
 
-#### 2. Verify the Installation
-
-After installation, verify that Snowfakery is installed by checking the version:
+#### Verify the Installation
 
 ```bash
 snowfakery --version
 ```
 
-You should see the version number of Snowfakery printed in the terminal, confirming a successful installation.
-
-#### Usage (Withou Salesforce Data Treecipe Extension)
-
-Once installed, you can generate synthetic data by running Snowfakery from the command line:
+#### Usage (Without Salesforce Data Treecipe Extension)
 
 ```bash
 snowfakery generate <path_to_your_snowfakery_recipe>
 ```
 
-For more information about writing Snowfakery recipes and using the tool, please refer to the official documentation:  
+Official documentation:
 [https://snowfakery.readthedocs.io/](https://snowfakery.readthedocs.io/)
 
 #### Uninstalling Snowfakery
 
-If you wish to uninstall Snowfakery, you can do so using pip:
-
 ```bash
 pip uninstall snowfakery
 ```
-

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Salesforce Data Treecipe",
   "description": "source-fidelity driven development, pairs well with cumulus-ci",
   "icon": "images/datatreecipe.webp",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
@@ -5,6 +5,7 @@ import { faker } from '@faker-js/faker';
 
 import { IFakerRecipeProcessor } from '../IFakerRecipeProcessor';
 import { ErrorHandlingService } from '../../ErrorHandlingService/ErrorHandlingService';
+import { ProcessedYamlWrapper } from '../../RecipeFakerService.ts/FakerJSRecipeFakerService/ProcessedYamlWrapper';
 
 export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
 
@@ -16,7 +17,10 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
         const yamlContent = fs.readFileSync(fullRecipeFileNamePath, 'utf8'); // Read the YAML file
         const parsedData = yaml.load(yamlContent) as any[]; 
     
-        let generatedData: any[] = [];
+        let processedYamlWrapper:ProcessedYamlWrapper = {
+            ObjectPropertyToExistingProcessedYaml: {},
+            VariablePropertyToExistingProcessedYaml: {}
+        };
     
         for (const entry of parsedData) {
 
@@ -26,17 +30,13 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
             if ( objectType !== undefined && variableName === undefined ) {
                 // handle object type declaration 
                 // this function evaluates directly to generated data because it loops over fieleds that get pushed to generated data - could be refactored
-                generatedData = await this.processObjectDeclarationForYamlDocumentItem(objectType, entry, generatedData);
+                processedYamlWrapper.ObjectPropertyToExistingProcessedYaml = await this.processObjectDeclarationForYamlDocumentItem(objectType, entry, processedYamlWrapper);
 
             } else if ( variableName !== undefined && objectType === undefined ) {
 
                 // handle variable type declaraition
-                const variableFakerJSVariableEvaluation = await this.processVariableDeclarationForYamlDocumentItem(entry);
-
-                generatedData.push({
-                    variableName: variableName,
-                    value: variableFakerJSVariableEvaluation,
-                });
+                const variableFakerJSVariableEvaluation = await this.processVariableDeclarationForYamlDocumentItem(entry, processedYamlWrapper);
+                processedYamlWrapper.VariablePropertyToExistingProcessedYaml[variableName] = variableFakerJSVariableEvaluation;
 
             } else if ( objectType !== undefined || variableName !== undefined ) {
                 // throw error statiing top loevel declarations miust have "var" or "object" declaration i nthe yaml document item
@@ -44,11 +44,13 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
 
         };
     
-        const jsonGeneratedData = JSON.stringify(generatedData, null, 2);
+        const jsonGeneratedData = JSON.stringify(processedYamlWrapper.ObjectPropertyToExistingProcessedYaml, null, 2);
         return jsonGeneratedData;
     }
 
-    async processObjectDeclarationForYamlDocumentItem(objectType: string, objectYamlEntry: any, generatedData: any) {
+    async processObjectDeclarationForYamlDocumentItem(objectType: string, 
+                                                        objectYamlEntry: any, 
+                                                        processedYamlWrapper: ProcessedYamlWrapper) {
         
         const nickname = objectYamlEntry.nickname;
         const count = objectYamlEntry.count || 1; // Default to 1 if count isn't provided
@@ -57,19 +59,19 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
         for (let i = 0; i < count; i++) {
 
             let fieldApiNameByFakerJSEvaluations: Record<string, string> = {};
-            for (const [fieldName, fieldExpression] of Object.entries(fieldsTemplate)) {
+            for (const [yamlFieldName, yamlFieldValue] of Object.entries(fieldsTemplate)) {
 
                 try {
 
-                    // if fieldexpression is variable syntax then look for existing generated value in generatedData by key
-                    fieldApiNameByFakerJSEvaluations[fieldName] = await this.evaluateFakerJSExpression(fieldExpression, 
-                                                                                                        fieldApiNameByFakerJSEvaluations, 
-                                                                                                        fieldName);
-
+                    fieldApiNameByFakerJSEvaluations[yamlFieldName] = await this.evaluateProvidedYamlPropertyValue(yamlFieldValue, 
+                                                                                                                    fieldApiNameByFakerJSEvaluations, 
+                                                                                                                    yamlFieldName,
+                                                                                                                    processedYamlWrapper);
+                
                 } catch (error) {
                     
                     const executedCommand = "FakerJSRecipeProcessor.generateFakeDataBySelectedRecipeFile";
-                    const customErrorMessage = `Error evaluating faker-js expression syntax << ${fieldName} - ${ fieldExpression } >> - ${error.message}`;
+                    const customErrorMessage = `Error evaluating faker-js expression syntax << ${yamlFieldName} - ${ yamlFieldValue } >> - ${error.message}`;
                     
                     const customFakerJSEvaluationError = new Error();
                     customFakerJSEvaluationError.message = customErrorMessage;
@@ -87,7 +89,7 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
                 
             }
 
-            generatedData.push({
+            processedYamlWrapper.ObjectPropertyToExistingProcessedYaml[objectType].push({
                 id: (i+1),
                 object: objectType,
                 nickname: nickname,
@@ -96,16 +98,20 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
 
         }
 
-        return generatedData;
+        return processedYamlWrapper;
     }
 
-    async processVariableDeclarationForYamlDocumentItem(varYamlEntry: any) {
+    async processVariableDeclarationForYamlDocumentItem(varYamlEntry: any, processedYamlData: any) {
         
         let fakerJSVariableEvaluation:any;
     
         try {
 
-            fakerJSVariableEvaluation = await this.getFakeValueFromFakerJSExpression(varYamlEntry.value);
+            let emptyFieldToPropertyEvaluations:Record<string, string> = null;
+            fakerJSVariableEvaluation = await this.evaluateProvidedYamlPropertyValue(varYamlEntry.value, 
+                                                                                        emptyFieldToPropertyEvaluations, 
+                                                                                        varYamlEntry.name,
+                                                                                        processedYamlData);
 
         } catch (error) {
             
@@ -173,24 +179,87 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
     
     }
 
-    async evaluateFakerJSExpression(fakerJSExpression: any, 
+    async evaluateProvidedYamlPropertyValue(providedYamlPropertyValue: any, 
                                     fieldApiNameByFakerJSEvaluations: Record<string, string>,
-                                    fieldApiNameToEvaluate: string): Promise<string> {
+                                    yamlPropertyFieldApiNameToEvaluate: string,
+                                    alreadyProcessedYamlWrapper: ProcessedYamlWrapper): Promise<string> {
 
-    
-        const dependentPicklistKeyIndicator = "if";
-        if ( (typeof fakerJSExpression !== 'string') 
-                && (dependentPicklistKeyIndicator in fakerJSExpression) 
-                && Object.keys(fakerJSExpression).length === 1 ) {
-    
-                const evaluatedRandomChoiceFromAvailablePicklistDependencyOptions = this.evaluateDependentPicklistFakerJSExpression(fakerJSExpression, fieldApiNameByFakerJSEvaluations, fieldApiNameToEvaluate);
-                return evaluatedRandomChoiceFromAvailablePicklistDependencyOptions;
+        
+        let processedYamlPropertyValue = null;
 
+        const fakerJSExpressionStartIndicator = "${{";
+        const fakerJSExpressionStopIndicator = "${{";
+        const containsExpressionSyntax = (typeof providedYamlPropertyValue === 'string' 
+                                        && providedYamlPropertyValue.includes(fakerJSExpressionStartIndicator) 
+                                        && providedYamlPropertyValue.includes(fakerJSExpressionStopIndicator) );
+
+        if ( containsExpressionSyntax ) {
+            
+            processedYamlPropertyValue = await this.getFakeValueFromFakerJSExpression(providedYamlPropertyValue, alreadyProcessedYamlWrapper.VariablePropertyToExistingProcessedYaml);
+
+        } else {
+
+            processedYamlPropertyValue = this.handleNonFakerJSExpressionSyntaxValueScenarios(providedYamlPropertyValue, 
+                                                                                                fieldApiNameByFakerJSEvaluations, 
+                                                                                                yamlPropertyFieldApiNameToEvaluate);
+        
         }
-    
-        const generatedFakerJSExpressionToFakeValue = await this.getFakeValueFromFakerJSExpression(fakerJSExpression);
 
-        return generatedFakerJSExpressionToFakeValue;
+        return processedYamlPropertyValue;
+
+    }
+
+    getVariableValueFromExistingProcessedYamlProperties(variableToAlreadyEvaluatedValueReferenceMap: Record<string, any>, variableNameFromExpression) {
+
+        let yamlValueFromVariable = null;
+
+        const fromPreviousGenerated = variableToAlreadyEvaluatedValueReferenceMap[variableNameFromExpression];
+        if ( fromPreviousGenerated !== undefined ) {
+            yamlValueFromVariable = fromPreviousGenerated;
+        } else {
+            const missingVariableKeyReferenceTodoMessage = "### TODO : THIS VARIABLE SETTING IS MADE BEFORE THE ACTUAL VARIABLE OBJECT. MOVE THE VARIABLE DELCARATION '- var: vaiable name ' ABOVE THIS SECTION OF THE RECIPE";
+            yamlValueFromVariable = missingVariableKeyReferenceTodoMessage;
+        }
+
+        return yamlValueFromVariable;
+
+    }
+
+    extractVariableNameFromExpressionSyntax(input: string): string {
+        const pattern = /\b(var\.[a-zA-Z_][a-zA-Z0-9_]*)\b/;
+        const match = input.match(pattern);
+        return match ? match[1] : null;
+
+    }
+
+
+    handleNonFakerJSExpressionSyntaxValueScenarios(providedYamlPropertyValue: any,
+                                                    fieldApiNameByFakerJSEvaluations,
+                                                    yamlPropertyFieldApiNameToEvaluate): any {
+
+        let evaluatedYamlPropertyValue = null;
+        const dependentPicklistKeyIndicator = "if";
+        if ( (typeof providedYamlPropertyValue !== 'string') 
+                && (dependentPicklistKeyIndicator in providedYamlPropertyValue) 
+                && Object.keys(providedYamlPropertyValue).length === 1 ) {
+    
+                const evaluatedRandomChoiceFromAvailablePicklistDependencyOptions = this.evaluateDependentPicklistFakerJSExpression(providedYamlPropertyValue, 
+                                                                                                                                    fieldApiNameByFakerJSEvaluations, 
+                                                                                                                                    yamlPropertyFieldApiNameToEvaluate);
+                evaluatedYamlPropertyValue = evaluatedRandomChoiceFromAvailablePicklistDependencyOptions;
+
+        } else {
+
+            /*
+                if no expected faker-js expression syntax, 
+                field value may be hard coded string or special value 
+                like object nickname or record type api name
+             */
+
+            evaluatedYamlPropertyValue = providedYamlPropertyValue;
+        }
+
+        return evaluatedYamlPropertyValue;
 
     }
 
@@ -278,16 +347,10 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
 
     }   
 
-    async getFakeValueFromFakerJSExpression(fakerJSExpression: string): Promise<string> {
+    async getFakeValueFromFakerJSExpression(fakerJSExpression: string, variableToEvaluatedValueReferenceMap): Promise<string> {
 
         const regexExpressionForFakerSyntaxBookEnds = FakerJSRecipeProcessor.regExpressionForSurroundingFakerJSSyntax;
-
         const expressionSyntaxMatches = [...fakerJSExpression.matchAll(regexExpressionForFakerSyntaxBookEnds)];
-
-        if (expressionSyntaxMatches.length === 0) {
-            // if no expected faker-js expression syntax, field value may be hard coded string or special value like object nickname or record type api name
-            return fakerJSExpression;
-        }
 
         let originalExpressionCopyForFakerEvalReplacements = fakerJSExpression;
 
@@ -299,11 +362,23 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
             const matchIndex = expressionMatch.index; 
             const matchCharactersLength = fullIndexMatch.length;
             const trimmedFakerJSCode = fakerJSCode.trim();
+
+            let processedYamlPropertyValueFromExpression = null;
+            const variableNameFromExpressionSyntax = this.extractVariableNameFromExpressionSyntax(trimmedFakerJSCode);
+            if ( variableNameFromExpressionSyntax !== null ) {
+
+                processedYamlPropertyValueFromExpression = this.getVariableValueFromExistingProcessedYamlProperties(variableToEvaluatedValueReferenceMap, variableNameFromExpressionSyntax);
+
+            } else {
+
+                processedYamlPropertyValueFromExpression = this.getFakerJSExpressionEvaluation(trimmedFakerJSCode);
+
+            }         
+
             
-            const fakerEvalExpressionResult = this.getFakerJSExpressionEvaluation(trimmedFakerJSCode);
             
             originalExpressionCopyForFakerEvalReplacements = originalExpressionCopyForFakerEvalReplacements.substring(0, matchIndex) + 
-                                                                fakerEvalExpressionResult + 
+                                                                processedYamlPropertyValueFromExpression + 
                                                                 originalExpressionCopyForFakerEvalReplacements.substring(matchIndex + matchCharactersLength);
         
         }
@@ -601,6 +676,8 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
     }
 
 }
+
+
 
 
 

--- a/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
@@ -38,11 +38,7 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
                 const variableFakerJSVariableEvaluation = await this.processVariableDeclarationForYamlDocumentItem(entry, processedYamlWrapper);
                 processedYamlWrapper.VariablePropertyToExistingProcessedYaml[variableName] = variableFakerJSVariableEvaluation;
 
-            } else {
-
-                // do nothing as there could be yaml used for somethign else like adding context to the recipe file
-
-            }
+            } 
 
         };
     
@@ -110,11 +106,10 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
             
             }
 
-         
-
         }
 
         return processedYamlWrapper;
+
     }
 
     async processVariableDeclarationForYamlDocumentItem(varYamlEntry: any, processedYamlData: any) {

--- a/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts
@@ -90,6 +90,31 @@ describe('Shared FakerJSRecipeProcessor tests', () => {
 
         });
 
+        test('should process variable expression syntax in YAML file and generate fake data', async () => {
+
+            const mockVariableYamlContent = RecipeMockService.getFakerJSMockVariableExpressionMarkup();
+            
+            jest.spyOn(fs, 'readFileSync').mockReturnValue(mockVariableYamlContent);
+            
+            // creating yaml.load "spy" to check what is being passed into the load argument
+            // this argument should be mockYamlContent as its the mock value used for fs.readFileSync
+            jest.spyOn(yaml, 'load');
+    
+            const fakeTestFile = 'test.yaml';                        
+            const result = await fakerJSRecipeProcessor.generateFakeDataBySelectedRecipeFile(fakeTestFile);
+
+            expect(fs.readFileSync).toHaveBeenCalledWith(fakeTestFile, 'utf8');
+
+            // below assert will not work without yaml spy
+            expect(yaml.load).toHaveBeenCalledWith(mockVariableYamlContent);
+
+            const parsedResult = JSON.parse(result);
+
+            expect(parsedResult.length).toBe(2);
+          
+
+        });
+
     });
 
     describe('transformFakerJsonDataToCollectionApiFormattedFilesBySObject', () => {

--- a/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts
+++ b/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts
@@ -432,7 +432,7 @@ ${this.generateTabs(5)}${randomChoicesBreakdown}`;
             "Product2": {
                 "Name": `\${{faker.commerce.productName()}}`,
                 "Description": `\${{faker.lorem.paragraph()}}`,
-                "ProductCode": `\${{faker.commerce.product()}}-{{faker.string.alphanumeric(6)}}`,
+                "ProductCode": `\${{faker.commerce.product()}}-\${{faker.string.alphanumeric(6)}}`,
                 "IsActive": `\${{faker.helpers.arrayElement(['true', 'false'])}}`,
                 "Family": `\${{faker.helpers.arrayElement(['Hardware', 'Software', 'Services', 'Other'])}}`,
                 "QuantityUnitOfMeasure": `\${{faker.helpers.arrayElement(['Each', 'Case', 'Box', 'Pallet'])}}`,

--- a/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/ProcessedYamlWrapper.ts
+++ b/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/ProcessedYamlWrapper.ts
@@ -1,0 +1,8 @@
+
+export class ProcessedYamlWrapper {
+  
+    ObjectPropertyToExistingProcessedYaml: Record<string, any>;
+    VariablePropertyToExistingProcessedYaml: Record<string, any>;
+  
+}
+

--- a/src/treecipe/src/RecipeService/tests/mocks/RecipeMockService.ts
+++ b/src/treecipe/src/RecipeService/tests/mocks/RecipeMockService.ts
@@ -365,5 +365,38 @@ return fakeRecordTypeRecipe;
 
     }
 
+    static getFakerJSVariableExpressionMarkup():string {
+        
+        const variableExpressionYaml = `
+- var: dogName
+  value: frank
+
+- var: dinoName 
+  value: "indominous"
+
+- var: animatedHero 
+  value: batman
+
+- var: randomDate
+  value: |
+    \${{ faker.date.between({ from: new Date('2023-01-01'), to: new Date() }).toISOString().split('T')[0] }}
+
+- var: multiPicklistVar
+  value: \${{ (faker.helpers.arrayElements(['chorizo','pork','steak','tofu'])).join(';') }} 
+
+- object: VariableAccount
+  count: 1
+  nickname: VariableAccountOne
+  fields:
+    VarDate__c: \${{ var.randomDate }}    
+    VarAnimatedHero__c: \${{ var.animatedHero }}
+    VarDogName__c: \${{ var.dogName }}  
+    VarDinoName__c: \${{ var.dinoName }} 
+`;
+
+        return variableExpressionYaml;
+
+    }
+
 
 }

--- a/src/treecipe/src/RecipeService/tests/mocks/RecipeMockService.ts
+++ b/src/treecipe/src/RecipeService/tests/mocks/RecipeMockService.ts
@@ -365,7 +365,7 @@ return fakeRecordTypeRecipe;
 
     }
 
-    static getFakerJSVariableExpressionMarkup():string {
+    static getFakerJSMockVariableExpressionMarkup():string {
         
         const variableExpressionYaml = `
 - var: dogName
@@ -379,7 +379,7 @@ return fakeRecordTypeRecipe;
 
 - var: randomDate
   value: |
-    \${{ faker.date.between({ from: new Date('2023-01-01'), to: new Date() }).toISOString().split('T')[0] }}
+    \${{ faker.date.between({ from: new Date('2023-01-01'), to: new Date('2023-02-01') }).toISOString().split('T')[0] }}
 
 - var: multiPicklistVar
   value: \${{ (faker.helpers.arrayElements(['chorizo','pork','steak','tofu'])).join(';') }} 

--- a/src/treecipe/src/RecipeService/tests/mocks/RecipeMockService.ts
+++ b/src/treecipe/src/RecipeService/tests/mocks/RecipeMockService.ts
@@ -428,7 +428,6 @@ return fakeRecordTypeRecipe;
   value: |
     \${{ "Steven" }}
 
-
 - object: VariableAccount
   count: 1
   nickname: VariableAccountOne

--- a/src/treecipe/src/RecipeService/tests/mocks/RecipeMockService.ts
+++ b/src/treecipe/src/RecipeService/tests/mocks/RecipeMockService.ts
@@ -398,5 +398,48 @@ return fakeRecordTypeRecipe;
 
     }
 
+     static getSmallFakerJSMockVariableExpressionMarkup():string {
+        
+        const variableExpressionYaml = `
+- var: randomDate
+  value: |
+    \${{ faker.date.between({ from: new Date('2023-01-01'), to: new Date('2023-02-01') }).toISOString().split('T')[0] }}
+
+- object: VariableAccount
+  count: 1
+  nickname: VariableAccountOne
+  fields:
+    SomeField: "tessst"    
+    VarDate__c: \${{ var.randomDate }}    
+`;
+
+        return variableExpressionYaml;
+
+    }
+
+     static getDoubleExpressionSmallFakerJSMockVariableExpressionMarkup():string {
+        
+        const variableExpressionYaml = `
+- var: randomDate
+  value: |
+    \${{ faker.date.between({ from: new Date('2023-01-01'), to: new Date('2023-02-01') }).toISOString().split('T')[0] }}
+
+- var: birthdayPerson
+  value: |
+    \${{ "Steven" }}
+
+
+- object: VariableAccount
+  count: 1
+  nickname: VariableAccountOne
+  fields:
+    SomeField: "tessst"    
+    VarWild: So much craziness getting prepared for \${{ var.birthdayPerson}} birthday on \${{ var.randomDate }}. I need to be sure to send out email to \${{ faker.internet.email() }}.    
+`;
+
+        return variableExpressionYaml;
+
+    }
+
 
 }


### PR DESCRIPTION
### Motivation and Context

A great feature to snowfakery that is missing from the faker-js implementation when generating fake data is the ability to reuse previously generated values, constants or hardcoded variable names. 

This functionality introduces a way for specific variable syntax to be leveraged in fake data recipe generation.

Below is an example.  ***NOTE*** - variables must be defined at a top-most line level above where the variable is referenced:

```yaml
- var: dogName
  value: frank

- var: dinoName 
  value: "indominous"

- var: animatedHero 
  value: batman

- var: randomDate
  value: |
    ${{ faker.date.between({ from: new Date('2023-01-01'), to: new Date('2023-02-01') }).toISOString().split('T')[0] }}

- var: multiPicklistVar
  value: ${{ (faker.helpers.arrayElements(['chorizo','pork','steak','tofu'])).join(';') }} 

- object: Account
  count: 1
  nickname: AccountWithCustomFieldsSetByVariables
  fields:
    VarDate__c: ${{ var.randomDate }}    
    VarAnimatedHero__c: ${{ var.animatedHero }}
    VarDogName__c: ${{ var.dogName }}  
    VarDinoName__c: ${{ var.dinoName }} 
```


### Any Technical Decisions to Note?

- Refactor the string-based variable that captured parsed yaml results. With the introduction of "variable" sequences we needed an effective way to add and reference keys captured for both variables and object sequences in the yaml file. Other work was done to structure this but that work supports the ability to do the below screen shot:

<img width="1318" alt="image" src="https://github.com/user-attachments/assets/e3f2008d-7776-4579-81f9-02cb2c9d887c" />


### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):


### How Has This Been Tested?
- [ ] Tested on Windows
- [x] Tested on macOS
- [ ] Tested on Linux
- [x] Added new unit tests
- [x] Updated existing tests

#### Test Details

With the introduction of "variables" being a new yaml syntax indicator, new unit tests were added to ensure the expected syntax is captured and values applied as expected. Other unit tests were refactored to manage scenarios that properly handled both variables and objects yaml syntax.

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

***

***

# Changelog for branch: feature/faker-js-variable-expression-syntax

Generated on: 2025-06-18

## Summary
- Total commits: 10
- Files added: 1
- Files modified: 7
- Files deleted: 0
- Files renamed: 0

*** 

## Changes at a glance
## Added Files
| Added File | Commits | History |
|------|---------|---------|
| src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/ProcessedYamlWrapper.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/faker-js-variable-expression-syntax/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/ProcessedYamlWrapper.ts) |
## Modified Files
| Modified File | Commits | History |
|------|---------|---------|
| .github/pull_request_template.md | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/faker-js-variable-expression-syntax/.github/pull_request_template.md) |
| CHANGELOG.md | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/faker-js-variable-expression-syntax/CHANGELOG.md) |
| package.json | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/faker-js-variable-expression-syntax/package.json) |
| src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts | 5 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/faker-js-variable-expression-syntax/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts) |
| src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts | 3 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/faker-js-variable-expression-syntax/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts) |
| src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/faker-js-variable-expression-syntax/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts) |
| src/treecipe/src/RecipeService/tests/mocks/RecipeMockService.ts | 4 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/faker-js-variable-expression-syntax/src/treecipe/src/RecipeService/tests/mocks/RecipeMockService.ts) |
## Deleted Files
| Deleted File | Commits | History |
|------|---------|---------|
## Renamed Files
| Old Path | New Path | Commits | History |
|----------|----------|---------|---------|
