### PR TITLE
Feature/nickname and reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@
 
 Feature: Leverage nickname property from yaml object recipe that can combine with unique "record reference key" to allow for lookup reference replacements. 
 
+With this update we can now leverage the yaml property "nickname" on a parent object.  When a child object needs to reference a parent to populate for a lookup or masterdetail field, it can provide the nickname as its value:
 
+```yaml
+
+- object: Account
+  nickname: ParentAccountNickname
+  fields:
+    Name: ${{ faker.company.name() }} 
+
+- object: Contact
+  fields:
+    FirstName: ${{ ... }}
+    LastName: ${{ ... }}
+    AccountId: ParentAccountNickname
+
+```
 
 ## [2.2.0] [PR#26](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/26) - Feature : 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
-## [2.2.0] [PR#25](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/26) - Feature : 2.2.0
+## [2.3.0] [PR#27](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/27) - Feature : 2.3.0
+
+Feature: Leverage nickname property from yaml object recipe that can combine with unique "record reference key" to allow for lookup reference replacements. 
+
+
+
+## [2.2.0] [PR#26](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/26) - Feature : 2.2.0
 
 Feature: Variable syntax capabilities using faker-js recipes
 

--- a/src/treecipe/src/CollectionsApiService/CollectionsApiService.ts
+++ b/src/treecipe/src/CollectionsApiService/CollectionsApiService.ts
@@ -468,10 +468,20 @@ export class CollectionsApiService {
 
     static updateLookupReferencesInCollectionApiJson(collectionsApiJson: string, objectReferenceIdToOrgCreatedRecordIdMap: Record<string, string>) {
 
+        const expectedDoubleUnderscoreForObjectRecipesThatIncludedNickname = "__";
         for (const [referenceIdKey, referenceIdAssociatedRecordIdValue ] of  Object.entries(objectReferenceIdToOrgCreatedRecordIdMap)) {
 
-            collectionsApiJson = collectionsApiJson.replaceAll(referenceIdKey, `${referenceIdAssociatedRecordIdValue}`);
-        
+            const splitReferenceIdentifiers = referenceIdKey.split(expectedDoubleUnderscoreForObjectRecipesThatIncludedNickname);
+
+            const incrementalObjectReferenceValue = splitReferenceIdentifiers[0];
+            collectionsApiJson = collectionsApiJson.replaceAll(incrementalObjectReferenceValue, `${referenceIdAssociatedRecordIdValue}`);
+
+            const nicknameValue = splitReferenceIdentifiers[1];
+            if ( nicknameValue ) {
+                // Not every object and associated could have a "nickname" property so the reference key would not include the double underscore split
+                collectionsApiJson = collectionsApiJson.replaceAll(nicknameValue, `${referenceIdAssociatedRecordIdValue}`);
+            }
+
         }
 
         return collectionsApiJson;

--- a/src/treecipe/src/CollectionsApiService/tests/CollectionsApiService.test.ts
+++ b/src/treecipe/src/CollectionsApiService/tests/CollectionsApiService.test.ts
@@ -399,6 +399,7 @@ describe('Shared tests for CollectionsApiService', () => {
         });
     
         test('should handle empty input arrays gracefully', () => {
+            
             const objectReferenceIdToOrgCreatedRecordIdMap: Record<string, string> = {};
     
             const result = CollectionsApiService.updateReferenceIdMapWithCreatedRecords(

--- a/src/treecipe/src/CollectionsApiService/tests/CollectionsApiService.test.ts
+++ b/src/treecipe/src/CollectionsApiService/tests/CollectionsApiService.test.ts
@@ -418,15 +418,30 @@ describe('Shared tests for CollectionsApiService', () => {
     describe('updateLookupReferencesInCollectionApiJson', () => {
     
         test('should replace reference IDs with corresponding record IDs', () => {
+
             const collectionsApiJson = '{"records":[{"Id":"ref1"},{"Id":"ref2"}]}';
             const objectReferenceIdToOrgCreatedRecordIdMap = {
-                ref1: '001ABC',
+                ref1__sweetNickname: '001ABC',
                 ref2: '002DEF',
             };
 
             const result = CollectionsApiService.updateLookupReferencesInCollectionApiJson(collectionsApiJson, objectReferenceIdToOrgCreatedRecordIdMap);
 
             expect(result).toBe('{"records":[{"Id":"001ABC"},{"Id":"002DEF"}]}');
+
+        });
+
+        test('nickname or associated reference value will operate as reference id that will get assigned Id value', () => {
+
+            const collectionsApiJson = '{"records":[{"Id":"ref1"},{"Id":"Nickname"}]}';
+            const objectReferenceIdToOrgCreatedRecordIdMap = {
+                ref1__Nickname: '001ABC',
+            };
+
+            const result = CollectionsApiService.updateLookupReferencesInCollectionApiJson(collectionsApiJson, objectReferenceIdToOrgCreatedRecordIdMap);
+
+            expect(result).toBe('{"records":[{"Id":"001ABC"},{"Id":"001ABC"}]}');
+
         });
 
         test('should replace multiple occurrences of the same reference ID', () => {

--- a/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts
@@ -155,7 +155,10 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
         fakerJSRecords.forEach(record => {
 
             const objectApiName = record.object;
-            const recordTrackingReferenceId = `${objectApiName}_Reference_${record.id}`;
+            const recordTrackingReferenceId = this.createCombinedNickNameReferenceForRecord(
+                objectApiName,
+                record
+            );
             const sobjectGeneratedDetail = {
                 attributes: {
                     type: objectApiName,
@@ -188,6 +191,17 @@ export class FakerJSRecipeProcessor implements IFakerRecipeProcessor {
 
         return objectApiToGeneratedRecords;
     
+    }
+
+    createCombinedNickNameReferenceForRecord(objectApiName:string, recordDetail: any):string {
+
+        let referenceTrackingId = `${objectApiName}_Reference_${recordDetail.id}`;
+        if ( recordDetail.nickname ) {
+            referenceTrackingId = `${referenceTrackingId}__${recordDetail.nickname}`;
+        }
+
+        return referenceTrackingId;
+
     }
 
     async evaluateProvidedYamlPropertyValue(providedYamlPropertyValue: any, 

--- a/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts
@@ -132,7 +132,9 @@ describe('Shared FakerJSRecipeProcessor tests', () => {
             expect(accountData).toBeDefined();
             expect(accountData.records.length).toBe(2);
             expect(accountData.records[0].attributes.type).toBe('Account');
-            expect(accountData.records[0].attributes.referenceId).toBe('Account_Reference_1');
+            expect(accountData.records[0].attributes.referenceId).toBe('Account_Reference_1__standard_account');
+            expect(accountData.records[1].attributes.referenceId).toBe('Account_Reference_2__coolNickname');
+
             expect(accountData.records[0].Name).toBe('Acme Corp');
             
             const contactData = actualMappedSObjectApiToRecords.get('Contact');

--- a/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/mocks/FakerJSExpressionMocker.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/mocks/FakerJSExpressionMocker.ts
@@ -70,7 +70,7 @@ export class FakerJSExpressionMocker {
             {
                 id: 2,
                 object: 'Account',
-                nickname: 'standard_account',
+                nickname: 'coolNickname',
                 fields: {
                     Name: 'Widget Inc',
                     Description: 'Quality products'

--- a/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/SnowfakeryRecipeProcessor.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/SnowfakeryRecipeProcessor.ts
@@ -87,7 +87,10 @@ export class SnowfakeryRecipeProcessor implements IFakerRecipeProcessor {
         snowfakeryRecords.forEach(record => {
 
             const objectApiName = record._table; // snowfakery captures the object api name value in _table property
-            const recordTrackingReferenceId = `${objectApiName}_Reference_${record.id}`;
+            const recordTrackingReferenceId = this.createCombinedNickNameReferenceForRecord(
+                objectApiName,
+                record
+            );
             const sobjectGeneratedDetail = {
                 attributes: {
                     type: objectApiName,
@@ -98,6 +101,7 @@ export class SnowfakeryRecipeProcessor implements IFakerRecipeProcessor {
           
             // remove snowfakery properties not needed for collections api 
             delete sobjectGeneratedDetail.id;
+            delete sobjectGeneratedDetail.nickname;
             delete sobjectGeneratedDetail._table;
 
             if (objectApiToGeneratedRecords.has(objectApiName)) {
@@ -120,6 +124,17 @@ export class SnowfakeryRecipeProcessor implements IFakerRecipeProcessor {
         return objectApiToGeneratedRecords;
 
     
+    }
+
+    createCombinedNickNameReferenceForRecord(objectApiName:string, recordDetail: any):string {
+
+        let referenceTrackingId = `${objectApiName}_Reference_${recordDetail.id}`;
+        if ( recordDetail.nickname ) {
+            referenceTrackingId = `${referenceTrackingId}__${recordDetail.nickname}`;
+        }
+
+        return referenceTrackingId;
+
     }
     
 }

--- a/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/tests/SnowfakeryRecipeProcessor.test.ts
+++ b/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/tests/SnowfakeryRecipeProcessor.test.ts
@@ -150,7 +150,7 @@ describe('Shared SnowfakeryRecipeProcessor tests', () => {
         test('given two different objects from snowfakery generation, calls createCollectionsApiFile twice', () => {
             
             const snowfakeryJsonFileContent = JSON.stringify([
-                { id: 1, _table: 'Account', name: 'Test Account' },
+                { id: 1, _table: 'Account', name: 'Test Account', nickname: 'coolCompanyNickname' },
                 { id: 2, _table: 'Contact', firstName: 'John', lastName: 'Doe' }
             ]);
 
@@ -163,7 +163,7 @@ describe('Shared SnowfakeryRecipeProcessor tests', () => {
                                 {
                                     attributes: {
                                     type: 'Account',
-                                    referenceId: 'Account_Reference_1'
+                                    referenceId: 'Account_Reference_1__coolCompanyNickname'
                                 },
                                 name: 'Test Account'
                             }


### PR DESCRIPTION
### Motivation and Context

When creating data recipes that are intended to be created an a target org, we need the ability to be able to create relationships between objects. This functionality is available using an convention of "Account_Reference_1" but this functionality is not documented and is a blind-faith approach to creating relationships between a child object and a parent object. 

With this update we can now leverage the yaml property "nickname" on a parent object.  When a child object needs to reference a parent to populate for a lookup or masterdetail field, it can provide the nickname as its value:

```yaml

- object: Account
  nickname: ParentAccountNickname
  fields:
    Name: ${{ faker.company.name() }} 

- object: Contact
  fields:
    FirstName: ${{ ... }}
    LastName: ${{ ... }}
    AccountId: ParentAccountNickname

```


### Any Technical Decisions to Note??

Introduced a convention when creating reference keys that will allow for pointing lookup fields to expected parent record ids using nickname or the incremental reference record ( "Account_Reference_1" ) 


### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):


### How Has This Been Tested?
- [ ] Tested on Windows
- [x] Tested on macOS
- [ ] Tested on Linux
- [x] Added new unit tests
- [x] Updated existing tests

#### Test Details
[Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration]

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


***

# Changelog for branch: feature/nicknameAndReference

Generated on: 2025-07-04

## Summary
- Total commits: 3
- Files added: 0
- Files modified: 8
- Files deleted: 0
- Files renamed: 0

*** 

## Changes at a glance
## Added Files
| Added File | Commits | History |
|------|---------|---------|
## Modified Files
| Modified File | Commits | History |
|------|---------|---------|
| CHANGELOG.md | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/nicknameAndReference/CHANGELOG.md) |
| src/treecipe/src/CollectionsApiService/CollectionsApiService.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/nicknameAndReference/src/treecipe/src/CollectionsApiService/CollectionsApiService.ts) |
| src/treecipe/src/CollectionsApiService/tests/CollectionsApiService.test.ts | 2 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/nicknameAndReference/src/treecipe/src/CollectionsApiService/tests/CollectionsApiService.test.ts) |
| src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/nicknameAndReference/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/FakerJSRecipeProcessor.ts) |
| src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/nicknameAndReference/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/FakerJSRecipeProcessor.test.ts) |
| src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/mocks/FakerJSExpressionMocker.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/nicknameAndReference/src/treecipe/src/FakerRecipeProcessor/FakerJSRecipeProcessor/tests/mocks/FakerJSExpressionMocker.ts) |
| src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/SnowfakeryRecipeProcessor.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/nicknameAndReference/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/SnowfakeryRecipeProcessor.ts) |
| src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/tests/SnowfakeryRecipeProcessor.test.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/feature/nicknameAndReference/src/treecipe/src/FakerRecipeProcessor/SnowfakeryRecipeProcessor/tests/SnowfakeryRecipeProcessor.test.ts) |
## Deleted Files
| Deleted File | Commits | History |
|------|---------|---------|
## Renamed Files
| Old Path | New Path | Commits | History |
|----------|----------|---------|---------|

