### PR TITLE
BUG : 2.5.1 -- Bug/globalvaluesetsingleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 
-## [2.5.0] [PR#29](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/32) - Feature : 2.5.0
+## [2.5.1] [PR#33](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/33) - Bug : 2.5.1
+
+Initial approach to capturing GlobalValueSets assumed that the singleton would be reset with every invocation of the "Generate Recipe" command.
+
+This was far from how VS Code session and state management function lol
+
+Instead of checking if the singleton was already initialized, we assume we need to retrieve the global value sets with every invocation. This allows for making updates to GlobalValueSet markup and files and re-running the Generate Recipe command and getting the updated faker function based on the latest from the Global Value Sets directory
+
+## [2.5.0] [PR#32](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/32) - Feature : 2.5.0
 
 ### Global Value Set Map for avoiding additional TODO's when generating recipes from code base
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Salesforce Data Treecipe",
   "description": "source-fidelity driven development, pairs well with cumulus-ci",
   "icon": "images/datatreecipe.webp",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/src/treecipe/src/ConfigurationService/ConfigurationService.ts
+++ b/src/treecipe/src/ConfigurationService/ConfigurationService.ts
@@ -15,6 +15,7 @@ export interface ExtensionConfig {
     selectedFakerService?: string;
     treecipeConfigurationPath?: string;
     useSnowfakeryAsDefault: boolean;
+    isGlobalValuesInitializedOnExtensionStartUp: boolean;
 }
 
 export interface TreecipeConfigDetail {

--- a/src/treecipe/src/ConfigurationService/ConfigurationService.ts
+++ b/src/treecipe/src/ConfigurationService/ConfigurationService.ts
@@ -15,7 +15,6 @@ export interface ExtensionConfig {
     selectedFakerService?: string;
     treecipeConfigurationPath?: string;
     useSnowfakeryAsDefault: boolean;
-    isGlobalValuesInitializedOnExtensionStartUp: boolean;
 }
 
 export interface TreecipeConfigDetail {

--- a/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory/MockDirectoryService.ts
+++ b/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory/MockDirectoryService.ts
@@ -101,6 +101,33 @@ export class MockDirectoryService {
     
   }
 
+  static getExpectedUpdatedMockGlobalValueSetsDirectoryStructure() {
+
+        // THE FORMATTING OF THIS EXPECTED DIRECTORIES IS AN EXACT MATCH TO HOW JSON.stringify WILL OUTPUT A DIRECTORY
+        // IT MAY BE AN ISSUE IN FUTURE ITERATIONS AND MAY MAKE SENSE TO USE THIS AND PERFORM WHITE SPACE REMOVAL TO FOCUS ON MATCHING 
+        // THE CONTENT ONLY
+        const expectedUpdatedGlobalValueSetMockDirectories = `[
+  {
+    "name": "CLEGlobal.globalValueSet-meta.xml",
+    "parentPath": "src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory/globalValueSets/GLEGlobal.globalValueSet-meta.xml",
+    "path": "src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory/globalValueSets"
+  },
+  {
+    "name": "Planets.globalValueSet-meta.xml",
+    "parentPath": "src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory/globalValueSets/Planets.globalValueSet-meta.xml",
+    "path": "src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory/globalValueSets"
+  },
+  {
+    "name": "ExtraUpdatedCaptainsCLEGlobal.globalValueSet-meta.xml",
+    "parentPath": "src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory/globalValueSets/ExtraUpdatedCaptainsCLEGlobal.globalValueSet-meta.xml",
+    "path": "src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory/globalValueSets"
+  }
+]`;
+      
+    return expectedUpdatedGlobalValueSetMockDirectories;
+    
+  }
+
   static getVSCodeFileTypeMockedObjectDirectories() {
 
       const rawData = JSON.parse(this.getExpectedMockObjectDirectoryStructure());
@@ -114,6 +141,16 @@ export class MockDirectoryService {
   static getVSCodeFileTypeMockedGlobalValueSetFiles() {
 
       const rawData = JSON.parse(this.getExpectedMockGlobalValueSetsDirectoryStructure());
+      const mockGVSFiles = rawData.map(entry => [
+          entry.name,
+          vscode.FileType.File
+      ]);
+      return mockGVSFiles;
+  }
+
+  static getVSCodeFileTypeUpdatedMockedGlobalValueSetFiles() {
+
+      const rawData = JSON.parse(this.getExpectedUpdatedMockGlobalValueSetsDirectoryStructure());
       const mockGVSFiles = rawData.map(entry => [
           entry.name,
           vscode.FileType.File

--- a/src/treecipe/src/ExtensionCommandService/ExtensionCommandService.ts
+++ b/src/treecipe/src/ExtensionCommandService/ExtensionCommandService.ts
@@ -120,7 +120,6 @@ export class ExtensionCommandService {
                 const pathToSalesforceMetadataParentDirectory = VSCodeWorkspaceService.getParentPath(fullPathToObjectsDirectory);
                 let globalValueSetSingleton = GlobalValueSetSingleton.getInstance();
                 globalValueSetSingleton.initialize(pathToSalesforceMetadataParentDirectory, isGlobalValuesInitializedOnExtensionStartUpOverride);
-                ConfigurationService.setExtensionConfigValue('isGlobalValuesInitializedOnExtensionStartUp', false);
 
                 const directoryProcessor = new DirectoryProcessor();
                 const objectsTargetUri = vscode.Uri.file(fullPathToObjectsDirectory);

--- a/src/treecipe/src/ExtensionCommandService/ExtensionCommandService.ts
+++ b/src/treecipe/src/ExtensionCommandService/ExtensionCommandService.ts
@@ -111,10 +111,16 @@ export class ExtensionCommandService {
                 const pathWithoutRelativeSyntax = relativePathToObjectsDirectory.split("./")[1];
                 const fullPathToObjectsDirectory = `${workspaceRoot}/${pathWithoutRelativeSyntax}`;
                 
-                // initialize globalvaluesets singleton
+                /* 
+                -- initialize globalvaluesets singleton --
+                 at this point in the extension commands, where a command is entered to generate a reciipe, we should retrieve the globalvaluesets 
+                 as there could be changes that have taken place throughout the vscode instance of the user
+                */
+                const isGlobalValuesInitializedOnExtensionStartUpOverride = false;
                 const pathToSalesforceMetadataParentDirectory = VSCodeWorkspaceService.getParentPath(fullPathToObjectsDirectory);
                 let globalValueSetSingleton = GlobalValueSetSingleton.getInstance();
-                globalValueSetSingleton.initialize(pathToSalesforceMetadataParentDirectory);
+                globalValueSetSingleton.initialize(pathToSalesforceMetadataParentDirectory, isGlobalValuesInitializedOnExtensionStartUpOverride);
+                ConfigurationService.setExtensionConfigValue('isGlobalValuesInitializedOnExtensionStartUp', false);
 
                 const directoryProcessor = new DirectoryProcessor();
                 const objectsTargetUri = vscode.Uri.file(fullPathToObjectsDirectory);

--- a/src/treecipe/src/GlobalValueSetSingleton/GlobalValueSetSingleton.ts
+++ b/src/treecipe/src/GlobalValueSetSingleton/GlobalValueSetSingleton.ts
@@ -9,13 +9,12 @@ export class GlobalValueSetSingleton {
 
     private static instance: GlobalValueSetSingleton | null = null;
     private globalValueSets: Record<string, string[]>;
-    private isInitialized: any;
 
     private constructor() {}
 
-    async initialize(salesforceMetadataParentPath: string): Promise<void> {
+    async initialize(salesforceMetadataParentPath: string, isGlobalValuesInitializedOnExtensionStartUp: boolean): Promise<void> {
 
-        if ( this.isInitialized ) {
+        if ( !(isGlobalValuesInitializedOnExtensionStartUp) ) {
             return;
         }
 
@@ -24,7 +23,6 @@ export class GlobalValueSetSingleton {
          
         // IF THERE IS NO "globalValueSets" directory, stop processing
         if (!fs.existsSync(expectedGlobalValueSetDirectoriesPath)) {
-            this.isInitialized = true;
             this.globalValueSets = null;
             vscode.window.showWarningMessage('No GlobalValueSets found in directory: ' + expectedGlobalValueSetDirectoriesPath);
             return;
@@ -65,8 +63,6 @@ export class GlobalValueSetSingleton {
             }
 
         }
-            
-        this.isInitialized = true;
 
     }
 

--- a/src/treecipe/src/GlobalValueSetSingleton/tests/GlobalValueSetSingleton.test.ts
+++ b/src/treecipe/src/GlobalValueSetSingleton/tests/GlobalValueSetSingleton.test.ts
@@ -36,6 +36,7 @@ describe("Shared GlobalValueSetSingletonService Tests", () => {
             const jsonMockedSalesforceMetadataDirectoryStructure = MockDirectoryService.getVSCodeFileTypeMockedGlobalValueSetFiles();
             const mockReadDirectory = jest.fn().mockResolvedValueOnce(jsonMockedSalesforceMetadataDirectoryStructure);
             jest.spyOn(vscode.workspace.fs, 'readDirectory').mockImplementation(mockReadDirectory);
+
             jest.spyOn(fs, 'existsSync').mockReturnValue(true);
 
             const cleGlobalValueSetXMLContent = XMLMarkupMockService.getCLEGlobalValueSetXMLMarkup();
@@ -59,7 +60,8 @@ describe("Shared GlobalValueSetSingletonService Tests", () => {
             });
 
             const uri = vscode.Uri.file('./src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory');
-            await globalValueSetSingleton.initialize(uri.fsPath);
+            const mimicIsCalledFromExtensionCommandOfGenerateRecipe = true;
+            await globalValueSetSingleton.initialize(uri.fsPath, mimicIsCalledFromExtensionCommandOfGenerateRecipe);
 
             const picklistApiNameToValues = globalValueSetSingleton.getPicklistValueMaps();
             expect(Object.keys(picklistApiNameToValues).length).toBe(2);
@@ -83,9 +85,15 @@ describe("Shared GlobalValueSetSingletonService Tests", () => {
                 return updatedExpectedGlobalValueSetFileNameToPicklistValuesSetMap[globalValueSetFileName] || Promise.resolve(null);
             });
 
-            await globalValueSetSingleton.initialize(uri.fsPath);
+            const jsonUpdatedMockedSalesforceMetadataDirectoryStructure = MockDirectoryService.getVSCodeFileTypeUpdatedMockedGlobalValueSetFiles();
+            const updatedMockReadDirectory = jest.fn().mockResolvedValueOnce(jsonUpdatedMockedSalesforceMetadataDirectoryStructure);
+            jest.spyOn(vscode.workspace.fs, 'readDirectory').mockImplementation(updatedMockReadDirectory);
+
+
+            await globalValueSetSingleton.initialize(uri.fsPath, mimicIsCalledFromExtensionCommandOfGenerateRecipe);
 
             const updatedPicklistApiNameToValues = globalValueSetSingleton.getPicklistValueMaps();
+
             expect(Object.keys(updatedPicklistApiNameToValues).length).toBe(3);
 
         });

--- a/src/treecipe/src/GlobalValueSetSingleton/tests/GlobalValueSetSingleton.test.ts
+++ b/src/treecipe/src/GlobalValueSetSingleton/tests/GlobalValueSetSingleton.test.ts
@@ -63,7 +63,31 @@ describe("Shared GlobalValueSetSingletonService Tests", () => {
 
             const picklistApiNameToValues = globalValueSetSingleton.getPicklistValueMaps();
             expect(Object.keys(picklistApiNameToValues).length).toBe(2);
+
+            const extraUpdatedCLEGlobalValueSetXMLContent = XMLMarkupMockService.getOneEXTRACLEGlobalValueSetXMLMarkup();
+            const updatedExpectedGlobalValueSetFileNameToPicklistValuesSetMap = {
+                'CLEGlobal.globalValueSet-meta.xml': Promise.resolve(
+                    cleGlobalValueSetXMLContent
+                ),
+                'Planets.globalValueSet-meta.xml': Promise.resolve(
+                    planetsGlobalValueSetXMLContent
+                ),
+                'ExtraUpdatedCaptainsCLEGlobal.globalValueSet-meta.xml': Promise.resolve(
+                    extraUpdatedCLEGlobalValueSetXMLContent
+                )
+            };
+
+            jest.spyOn(globalValueSetSingleton, 'getGlobalValueSetPicklistXMLFileContent')
+                .mockImplementation(async (globalValueSetURI, globalValueSetFileName) => {
             
+                return updatedExpectedGlobalValueSetFileNameToPicklistValuesSetMap[globalValueSetFileName] || Promise.resolve(null);
+            });
+
+            await globalValueSetSingleton.initialize(uri.fsPath);
+
+            const updatedPicklistApiNameToValues = globalValueSetSingleton.getPicklistValueMaps();
+            expect(Object.keys(updatedPicklistApiNameToValues).length).toBe(3);
+
         });
 
     });

--- a/src/treecipe/src/RecipeService/tests/FakerJSRecipeService.test.ts
+++ b/src/treecipe/src/RecipeService/tests/FakerJSRecipeService.test.ts
@@ -117,8 +117,10 @@ describe('FakerJSRecipeService IRecipeService Implementation Shared Intstance Te
                 return expectedGlobalValueSetFileNameToPicklistValuesSetMap[globalValueSetFileName] || Promise.resolve(null);
             });
     
+            const generateRecipeOverride = true;
+
             const uri = vscode.Uri.file('./src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory');
-            await globalValueSetSingleton.initialize(uri.fsPath);
+            await globalValueSetSingleton.initialize(uri.fsPath, generateRecipeOverride);
 
             const expectedPicklistXMLFieldDetail:XMLFieldDetail = XMLMarkupMockService.getExpectedGlobalValueSetCLEGlobalPicklistXMLFieldDetail();
             const expectedPicklistFakerJSValue = "\${{ faker.helpers.arrayElement(['guardians','cavs','browns','monsters','crunch']) }}";

--- a/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
+++ b/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts
@@ -782,6 +782,49 @@ export class XMLMarkupMockService {
 
     }
 
+    static getOneEXTRACLEGlobalValueSetXMLMarkup() {
+
+        const globalValueSetMarkup = `<?xml version="1.0" encoding="UTF-8"?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+   <customValue>
+        <fullName>captains</fullName>
+        <default>false</default>
+        <label>captains</label>
+    </customValue>
+    <customValue>
+        <fullName>guardians</fullName>
+        <default>false</default>
+        <label>guardians</label>
+    </customValue>
+    <customValue>
+        <fullName>cavs</fullName>
+        <default>false</default>
+        <label>cavs</label>
+    </customValue>
+    <customValue>
+        <fullName>browns</fullName>
+        <default>false</default>
+        <label>browns</label>
+    </customValue>
+    <customValue>
+        <fullName>monsters</fullName>
+        <default>false</default>
+        <label>monsters</label>
+    </customValue>
+    <customValue>
+        <fullName>crunch</fullName>
+        <default>false</default>
+        <label>crunch</label>
+    </customValue>
+    <masterLabel>ExtraUpdatedCaptainsCLEGlobal</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>
+`;
+
+        return globalValueSetMarkup;
+
+    }
+
     static getPlanetsGlobalValueSetXMLFileContent() {
         
         const planetsXmlFileContent = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
### Motivation and Context

BUG 

Initial approach to capturing GlobalValueSets assumed that the singleton would be reset with every invocation of the "Generate Recipe" command.

This was far from how VS Code session and state management function lol

Instead of checking if the singleton was already initialized, we assume we need to retrieve the global value sets with every invocation. This allows for making updates to GlobalValueSet markup and files and re-running the Generate Recipe command and getting the updated faker function based on the latest from the Global Value Sets directory

### Any Technical Decisions to Note??

- Adjusted how the GlobalValueSetSingleton was used and how it gets reset with each invocation of the "Generate Recipe" command


### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):


### How Has This Been Tested?
- [ ] Tested on Windows
- [x] Tested on macOS
- [ ] Tested on Linux
- [ ] Added new unit tests
- [x] Updated existing tests

#### Test Details

- Created a scenario where the GlobalValueSetSingleton is initialized, then update the mock directory to include a new Global Value Set, then run the "initialize" method again, to ensure the GlobalValueSets map gets updated with the latest source update

### Checklist
- [x] Pull Request title captures expected version update 
- [x] package.json version number updated
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

***

# Changelog for branch: bug/globalvaluesetsingleton

Generated on: 2025-09-03

## Summary
- Total commits: 3
- Files added: 0
- Files modified: 9
- Files deleted: 0
- Files renamed: 0


***

# Changelog for branch: bug/globalvaluesetsingleton

Generated on: 2025-09-03

## Summary
- Total commits: 4
- Files added: 0
- Files modified: 8
- Files deleted: 0
- Files renamed: 0

*** 

## Changes at a glance
## Added Files
| Added File | Commits | History |
|------|---------|---------|
## Modified Files
| Modified File | Commits | History |
|------|---------|---------|
| CHANGELOG.md | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/bug/globalvaluesetsingleton/CHANGELOG.md) |
| package.json | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/bug/globalvaluesetsingleton/package.json) |
| src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory/MockDirectoryService.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/bug/globalvaluesetsingleton/src/treecipe/src/DirectoryProcessingService/tests/mocks/MockSalesforceMetadataDirectory/MockDirectoryService.ts) |
| src/treecipe/src/ExtensionCommandService/ExtensionCommandService.ts | 2 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/bug/globalvaluesetsingleton/src/treecipe/src/ExtensionCommandService/ExtensionCommandService.ts) |
| src/treecipe/src/GlobalValueSetSingleton/GlobalValueSetSingleton.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/bug/globalvaluesetsingleton/src/treecipe/src/GlobalValueSetSingleton/GlobalValueSetSingleton.ts) |
| src/treecipe/src/GlobalValueSetSingleton/tests/GlobalValueSetSingleton.test.ts | 2 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/bug/globalvaluesetsingleton/src/treecipe/src/GlobalValueSetSingleton/tests/GlobalValueSetSingleton.test.ts) |
| src/treecipe/src/RecipeService/tests/FakerJSRecipeService.test.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/bug/globalvaluesetsingleton/src/treecipe/src/RecipeService/tests/FakerJSRecipeService.test.ts) |
| src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts | 1 | [View Full History](https://github.com/jdschleicher/Salesforce-Data-Treecipe/commits/bug/globalvaluesetsingleton/src/treecipe/src/XMLProcessingService/tests/mocks/XMLMarkupMockService.ts) |
## Deleted Files
| Deleted File | Commits | History |
|------|---------|---------|
## Renamed Files
| Old Path | New Path | Commits | History |
|----------|----------|---------|---------|
