### PR TITLE
Feature/mermaid separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [2.9.0] - Mermaid ERD Dedicated File & MermaidService Extraction
+## [2.9.0][PR#37](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/37) - Mermaid ERD Dedicated File & MermaidService Extraction
 
 ### 🎯 Major Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Change Log
 
+## [2.8.0] - Feature: SOQL & SOSL Query Template Builder
+
+### 🎯 Major Features
+
+#### 1. **Per-Tree SOQL & SOSL Query Template File**
+
+Each generated Treecipe recipe folder now includes a companion Markdown file (`soql-sosl-templates--{tree-name}-{timestamp}.md`) alongside the recipe YAML. The file is scoped to the objects in that specific relationship hierarchy — one template file per relationship tree, not one combined file for all objects.
+
+**File location:** written into the same subfolder as the recipe YAML (e.g., `Account-thru-OrderItem/`).
+
+#### 2. **Mermaid Entity Relationship Diagram**
+
+The template file opens with a `mermaid erDiagram` block showing all entities and relationships for that tree:
+
+- Object fields rendered as typed attributes (`string`, `number`, `date`, `datetime`, `boolean`)
+- Lookup fields rendered as `|o--o{` relationship lines (optional parent)
+- MasterDetail fields rendered as `||--o{` relationship lines (required parent)
+- Cross-tree relationships intentionally excluded — the diagram reflects only the objects in the current recipe
+
+#### 3. **Per-Object SOQL Query Sections**
+
+For each object in the tree, the template includes:
+
+- **Base Query** — `SELECT Id, <all fields> FROM Object__c`
+- **Child-to-Parent Queries** — one per Lookup/MasterDetail field, using relationship dot-notation (`Account.Name`) with up to five parent fields traversed
+- **Parent-to-Child Queries** — subquery per child object in the same tree (`SELECT Id, ... FROM ChildRelationship__r`)
+- **Record Type Filtered Queries** — one `WHERE RecordType.DeveloperName = 'X'` variant per detected record type
+- **SOSL Template** — `FIND {searchTerm} IN ALL FIELDS RETURNING Object(text-fields)` scoped to text-type fields only
+
+### 🔧 Technical Details
+
+- New `SOQLTemplateService` follows the existing service-per-folder pattern (`src/treecipe/src/SOQLTemplateService/`)
+- `generateSOQLTemplateMarkdownForTree(objectInfoWrapper, treeObjectNames, timestamp)` filters the full wrapper to only the tree's objects, guaranteeing cross-tree isolation in both queries and the ERD
+- `buildParentToChildSubqueries` skips children not present in the current filtered wrapper, preventing cross-tree relationship bleed
+- Integration point: `DirectoryProcessor.createRecipeFilesInSubdirectory()` calls the service inside the per-recipe-file loop, immediately after writing the YAML, using the same `treecipeTopToBottomLevelName` in the filename
+- 38 unit tests added in `SOQLTemplateService/tests/`
+
+---
+
 ## [2.7.0] [PR#35](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/35) - Feature: Enhanced Text & Numeric Field Precision Handling
 
 ### 🎯 Major Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [2.8.0] - Feature: SOQL & SOSL Query Template Builder
+## [2.8.0][PR#36](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/36) - Feature: SOQL & SOSL Query Template Builder
 
 ### 🎯 Major Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Change Log
 
+## [2.9.0] - Mermaid ERD Dedicated File & MermaidService Extraction
+
+### 🎯 Major Features
+
+#### 1. **Dedicated Mermaid ERD Markdown File**
+
+The Mermaid entity relationship diagram has been moved out of the SOQL/SOSL template file and into its own dedicated companion file (`mermaid-erd--{tree-name}-{timestamp}.md`). This separates concerns: the SOQL/SOSL template file focuses purely on query templates, while the ERD file stands alone for diagram rendering and documentation.
+
+**File naming:** `mermaid-erd--{treecipeTopToBottomLevelName}-{timestamp}.md` — written into the same subfolder as the recipe YAML and SOQL template.
+
+#### 2. **Titled Mermaid ERD File**
+
+The dedicated ERD file includes a descriptive header and explanatory prose before the diagram:
+
+- `# Entity Relationship Diagram` title
+- Description of what the diagram shows (typed fields, relationship cardinalities)
+- Explanation of `|o--o{` (Lookup, optional parent) vs `||--o{` (MasterDetail, required parent) notation
+- Generated timestamp and object list
+- Cross-tree exclusion note
+
+#### 3. **MermaidService Extraction**
+
+Mermaid ERD generation logic has been extracted from `SOQLTemplateService` into a dedicated `MermaidService` (`src/treecipe/src/MermaidService/`), following the existing service-per-folder pattern. `SOQLTemplateService` delegates ERD generation to `MermaidService`.
+
+### 🔧 Technical Details
+
+- New `MermaidService` class with `buildMermaidERD()`, `generateMermaidMarkdown()`, and `generateMermaidMarkdownForTree()` methods
+- `DirectoryProcessor` writes both `soql-sosl-templates--*.md` and `mermaid-erd--*.md` per recipe tree
+- SOQL/SOSL template file no longer contains the `## Entity Relationship Diagram` section
+- Unit tests added for `MermaidService`; `SOQLTemplateService` tests updated to reflect ERD removal
+
+---
+
 ## [2.8.0][PR#36](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/36) - Feature: SOQL & SOSL Query Template Builder
 
 ### 🎯 Major Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,243 @@
+# Claude Code Assistant Instructions - Salesforce Data Treecipe
+
+## AI Context & Project Overview
+
+You are assisting with **Salesforce Data Treecipe**, a **VS Code extension** (TypeScript) that auto-generates fake-data recipe YAML files from Salesforce object metadata (source format). It supports two faker backends: **faker-js** (built-in, no setup) and **snowfakery** (external Python CLI). The extension bridges Salesforce source-format XML metadata → YAML recipe files → Salesforce Collections API datasets.
+
+### Key Project Files
+
+- `src/extension.ts` - VS Code extension entry point; registers all commands
+- `src/treecipe/src/` - All core service logic (one folder per service)
+- `src/treecipe/src/RecipeFakerService.ts/` - **Directory** (not a file) containing `FakerJSRecipeFakerService/` and `SnowfakeryRecipeFakerService/` implementations
+- `src/treecipe/src/FakerRecipeProcessor/` - Interface + FakerJS and Snowfakery recipe processor implementations
+- `src/treecipe/src/DirectoryProcessingService/` - Parses Salesforce object metadata XML directories
+- `src/treecipe/src/RelationshipService/` - Groups objects into Treecipe files by relationship hierarchy
+- `src/treecipe/src/RecipeService/` - Orchestrates recipe YAML file creation
+- `package.json` - Extension manifest; all five commands declared under `contributes.commands`
+- `jest.config.js` - Jest configuration (`ts-jest`, `jest-extended`)
+- `CHANGELOG.md` - Feature history; read before starting work to understand recent changes
+
+## Primary Objectives
+
+1. **Follow existing service patterns** - Each service is a class in its own folder; tests live in a `tests/` subfolder alongside the service file
+2. **Field-type-driven generation** - Recipe output is determined by Salesforce XML `<type>` tag; use `<precision>` and `<scale>` to constrain numeric/currency values
+3. **Support both faker backends** - Every field-type handler must have equivalent implementations in both `FakerJSRecipeFakerService` and `SnowfakeryRecipeFakerService`
+4. **Write tests first** - Every service has a `tests/` folder with Jest specs; add or update tests with every change
+
+## Quick Command Reference
+
+```bash
+# Compile TypeScript
+npm run compile
+
+# Watch mode (auto-recompile on save)
+npm run watch
+
+# Run all tests with coverage
+npm run jest-test
+
+# Run tests with JSON + summary output (for CI)
+npm run jest-test-summary
+
+# Lint
+npm run lint
+
+# Run a single test file
+npx jest path/to/SomeService.test.ts
+
+# Package the extension
+npx vsce package
+```
+
+## CRITICAL RULES - NO EXCEPTIONS
+
+### After Every Code Change
+
+1. **Run tests** - `npm run jest-test` — ALL must pass
+2. **Check coverage** - Coverage must not regress
+3. **Compile** - `npm run compile` — zero TypeScript errors
+4. **Lint** - `npm run lint` — zero ESLint errors
+5. Check that existing functionality is not broken
+6. Follow the established code patterns in the project
+
+### Testing Requirements
+
+- **Tests are mandatory** - Run `npm run jest-test` after EVERY code change
+- **Update tests each change** - When modifying any service, add or update the corresponding test file in its `tests/` folder
+- **Tests must pass before committing** - Never commit code with failing tests
+- **Test coverage grows with features** - Every new feature, bug fix, or refactor must include relevant test updates
+- **Mock fixtures** - Place sample Salesforce XML metadata in `tests/mocks/` inside the relevant service folder
+- Use Jest `describe`/`it` or `describe`/`test` blocks; use `jest-extended` matchers where appropriate
+- `restoreMocks: true` is set globally — do not manually restore mocks between tests
+
+### Code Style Mandates
+
+- **TypeScript strict** - No implicit `any`; always define types/interfaces
+- **Class-based services** - Each service is a `class` with `static` methods; no standalone functions scattered outside a class
+- **Interface-first for faker services** - Both faker backends implement `IRecipeFakerService` and `IFakerRecipeProcessor`
+- **No hard-coded Salesforce field values** - All field type mappings must be driven by the XML `<type>` value
+- **Naming conventions** - PascalCase for classes/interfaces, camelCase for methods/variables; service files match their class name
+- **No comments for self-evident code** - Only add comments where the logic is non-obvious
+
+## Project Structure
+
+```
+src/
+├── extension.ts                             # Extension entry point, command registration
+└── treecipe/src/
+    ├── CollectionsApiService/
+    │   ├── CollectionsApiService.ts         # Formats fake data for Salesforce Collections API
+    │   ├── ICollectionsApiJsonStructure.ts  # Interface for Collections API payload shape
+    │   └── tests/
+    ├── ConfigurationService/
+    │   ├── ConfigurationService.ts          # Reads/writes treecipe.config.json
+    │   └── tests/
+    ├── DirectoryProcessingService/
+    │   ├── DirectoryProcessor.ts            # Walks Salesforce objects/ directory, parses XML
+    │   └── tests/
+    │       └── mocks/                       # Sample Salesforce metadata XML fixtures
+    ├── ErrorHandlingService/
+    │   ├── ErrorHandlingService.ts          # try-catch wrappers, GitHub Issue template generation
+    │   └── tests/
+    ├── ExtensionCommandService/
+    │   └── ExtensionCommandService.ts       # VS Code command handler implementations
+    ├── FakerRecipeProcessor/
+    │   ├── IFakerRecipeProcessor.ts         # Interface both processors implement
+    │   ├── FakerJSRecipeProcessor/
+    │   │   └── FakerJSRecipeProcessor.ts
+    │   └── SnowfakeryRecipeProcessor/
+    │       └── SnowfakeryRecipeProcessor.ts
+    ├── GlobalValueSetSingleton/
+    │   ├── GlobalValueSetSingleton.ts       # Shared picklist global value set state
+    │   └── tests/
+    ├── ObjectInfoWrapper/
+    │   ├── ObjectInfo.ts                    # Typed wrapper for parsed Salesforce object metadata
+    │   ├── ObjectInfoWrapper.ts
+    │   ├── FieldInfo.ts
+    │   └── tests/
+    ├── RecipeFakerService.ts/               # DIRECTORY (not a file)
+    │   ├── IRecipeFakerService.ts           # Interface both faker services implement
+    │   ├── FakerJSRecipeFakerService/
+    │   │   ├── FakerJSRecipeFakerService.ts # faker-js YAML recipe generation per field type
+    │   │   ├── ProcessedYamlWrapper.ts
+    │   │   └── tests/
+    │   └── SnowfakeryRecipeFakerService/
+    │       ├── SnowfakeryRecipeFakerService.ts # Snowfakery YAML recipe generation per field type
+    │       └── tests/
+    ├── RecipeService/
+    │   ├── RecipeService.ts                 # Orchestrates recipe YAML file creation end-to-end
+    │   └── tests/
+    │       └── mocks/
+    ├── RecordTypeService/
+    │   ├── RecordTypeService.ts             # Detects record types and related picklist options
+    │   ├── RecordTypesWrapper.ts
+    │   └── tests/
+    ├── RelationshipService/
+    │   ├── RelationshipService.ts           # Builds object relationship hierarchy for Treecipe grouping
+    │   └── tests/
+    │       └── mocks/
+    ├── ValueSetService/
+    │   └── ValueSetService.ts               # Parses picklist/global value set XML
+    ├── VSCodeWorkspace/
+    │   ├── VSCodeWorkspaceService.ts        # VS Code workspace/UI utilities (file picker, messages)
+    │   └── tests/
+    │       └── mocks/
+    └── XMLProcessingService/
+        ├── XmlFileProcessor.ts              # XML parsing utilities (xml2js wrapper)
+        └── XMLFieldDetail.ts               # Typed field detail from parsed XML
+```
+
+## Architecture Patterns
+
+### Extension Command Flow
+
+```
+User runs command (Cmd+Shift+P)
+  → extension.ts registers command → ExtensionCommandService handler
+    → ConfigurationService reads treecipe.config.json
+      → DirectoryProcessingService walks salesforceObjectsPath
+        → XmlFileProcessor parses each field's XML
+          → ObjectInfoWrapper wraps parsed metadata
+            → RecordTypeService / ValueSetService / RelationshipService enrich data
+              → RecipeService orchestrates YAML generation
+                → FakerJSRecipeFakerService OR SnowfakeryRecipeFakerService
+                  → generates faker expression per field type
+                → Writes YAML recipe file(s) to workspace
+```
+
+### Key Design Decisions
+
+- **`RecipeFakerService.ts` is a directory** — it contains both faker implementations as subfolders; this naming is intentional and must not be changed
+- **Both faker backends must stay in sync** — whenever a new field type handler is added to `FakerJSRecipeFakerService`, add the equivalent to `SnowfakeryRecipeFakerService`
+- **Numeric/currency precision** — `<precision>` (total digits) and `<scale>` (decimal places) from XML drive `max` and `dec` parameters; `left_digits = precision - scale`
+- **Picklist handling** — special characters (`&`, `'`, etc.) in picklist values must be escaped before embedding in faker expressions
+- **Relationship grouping** — `RelationshipService` determines which objects belong in the same Treecipe file and in what insertion order
+
+### VS Code Commands (package.json)
+
+| Command ID | Title |
+|---|---|
+| `treecipe.initiateConfiguration` | Initiate Configuration File |
+| `treecipe.generateTreecipe` | Generate Treecipe |
+| `treecipe.runFakerByRecipe` | Run Faker by Recipe |
+| `treecipe.insertDataSetBySelectedDirectory` | Insert Data Set by Directory |
+| `treecipe.changeFakerImplementationService` | Select Faker Implementation |
+
+---
+
+## Implementation Checklist
+
+When implementing a new feature or fixing a bug:
+
+- [ ] Read the relevant service file(s) before making changes
+- [ ] Add or update tests in the service's `tests/` folder
+- [ ] If adding a new Salesforce field type handler, implement it in **both** `FakerJSRecipeFakerService` and `SnowfakeryRecipeFakerService`
+- [ ] Add XML fixture files to `tests/mocks/` if the change depends on specific XML markup
+- [ ] Run `npm run jest-test` — all tests pass, coverage does not regress
+- [ ] Run `npm run compile` — zero TypeScript errors
+- [ ] Run `npm run lint` — zero ESLint errors
+- [ ] Update `CHANGELOG.md` with the change under an appropriate version heading
+
+## Common Tasks
+
+### Adding a New Salesforce Field Type Handler
+
+1. Identify the Salesforce `<type>` value (e.g., `"Checkbox"`, `"Date"`)
+2. Add a handler in `FakerJSRecipeFakerService.ts` that returns the appropriate faker-js expression
+3. Add the equivalent handler in `SnowfakeryRecipeFakerService.ts`
+4. Add tests for both in their respective `tests/` folders, with sample XML in `mocks/`
+
+### Adding a New VS Code Command
+
+1. Declare it in `package.json` under `contributes.commands`
+2. Register it in `extension.ts`
+3. Implement the handler in `ExtensionCommandService.ts`
+4. Wrap in `ErrorHandlingService` for consistent error reporting
+
+### Running Tests for a Specific Service
+
+```bash
+npx jest DirectoryProcessingService
+npx jest FakerJSRecipeFakerService
+npx jest --testPathPattern="RecipeFakerService"
+```
+
+### Checking What Changed Recently
+
+```bash
+# Read CHANGELOG.md top section, or:
+git log --oneline -10
+```
+
+## Remember
+
+- **Both faker backends** - New field type handlers must be implemented in both FakerJS and Snowfakery services
+- **Tests first** - Add/update tests in the service's `tests/` folder before or alongside code changes
+- **No comments for obvious code** - Only comment where logic is genuinely non-obvious
+- **`RecipeFakerService.ts` is a directory** - Do not confuse it with the `.ts` file of the same name in the parent folder
+- **Precision/scale math** - `left_digits = precision - scale`; `max = 10^left_digits - 1`; `dec = scale`
+- **Special characters in picklists** - Always escape before embedding in faker expression strings
+
+---
+
+_This document is optimized for Claude Code. Refer to `README.md` for end-user documentation and `CHANGELOG.md` for version history._

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Salesforce Data Treecipe",
   "description": "source-fidelity driven development, pairs well with cumulus-ci",
   "icon": "images/datatreecipe.webp",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Salesforce Data Treecipe",
   "description": "source-fidelity driven development, pairs well with cumulus-ci",
   "icon": "images/datatreecipe.webp",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts
+++ b/src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts
@@ -12,6 +12,7 @@ import * as path from 'path';
 import { RecordTypeWrapper } from '../RecordTypeService/RecordTypesWrapper';
 import { RelationshipService } from '../RelationshipService/RelationshipService';
 import { VSCodeWorkspaceService } from '../VSCodeWorkspace/VSCodeWorkspaceService';
+import { SOQLTemplateService } from '../SOQLTemplateService/SOQLTemplateService';
 
 export class DirectoryProcessor {
 
@@ -289,13 +290,24 @@ export class DirectoryProcessor {
           const outputFilePath = `${treecipeTopToBottomFolder}/${recipeFileName}`;
 
           fs.writeFile(outputFilePath, recipeFile.content, (err) => {
-              
+
             if (err) {
                   throw new Error('an error occurred when parsing objects directory and generating a recipe yaml file.');
             } else {
                   vscode.window.showInformationMessage('Treecipe YAML generated successfully');
             }
-              
+
+          });
+
+          const soqlTemplateFileName = `soql-sosl-templates--${treecipeTopToBottomLevelName}-${isoDateTimestamp}.md`;
+          const soqlTemplateFilePath = `${treecipeTopToBottomFolder}/${soqlTemplateFileName}`;
+          const soqlTemplateContent = SOQLTemplateService.generateSOQLTemplateMarkdownForTree(objectsInfoWrapper, recipeFile.objects, isoDateTimestamp);
+          fs.writeFile(soqlTemplateFilePath, soqlTemplateContent, (err) => {
+              if (err) {
+                  throw new Error(`an error occurred when attempting to create the "${soqlTemplateFileName}" file.`);
+              } else {
+                  vscode.window.showInformationMessage('SOQL/SOSL template file generated successfully');
+              }
           });
 
       }

--- a/src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts
+++ b/src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts
@@ -13,6 +13,7 @@ import { RecordTypeWrapper } from '../RecordTypeService/RecordTypesWrapper';
 import { RelationshipService } from '../RelationshipService/RelationshipService';
 import { VSCodeWorkspaceService } from '../VSCodeWorkspace/VSCodeWorkspaceService';
 import { SOQLTemplateService } from '../SOQLTemplateService/SOQLTemplateService';
+import { MermaidService } from '../MermaidService/MermaidService';
 
 export class DirectoryProcessor {
 
@@ -307,6 +308,17 @@ export class DirectoryProcessor {
                   throw new Error(`an error occurred when attempting to create the "${soqlTemplateFileName}" file.`);
               } else {
                   vscode.window.showInformationMessage('SOQL/SOSL template file generated successfully');
+              }
+          });
+
+          const mermaidErdFileName = `mermaid-erd--${treecipeTopToBottomLevelName}-${isoDateTimestamp}.md`;
+          const mermaidErdFilePath = `${treecipeTopToBottomFolder}/${mermaidErdFileName}`;
+          const mermaidErdContent = MermaidService.generateMermaidMarkdownForTree(objectsInfoWrapper, recipeFile.objects, isoDateTimestamp);
+          fs.writeFile(mermaidErdFilePath, mermaidErdContent, (err) => {
+              if (err) {
+                  throw new Error(`an error occurred when attempting to create the "${mermaidErdFileName}" file.`);
+              } else {
+                  vscode.window.showInformationMessage('Mermaid ERD file generated successfully');
               }
           });
 

--- a/src/treecipe/src/MermaidService/MermaidService.ts
+++ b/src/treecipe/src/MermaidService/MermaidService.ts
@@ -1,0 +1,128 @@
+import { ObjectInfoWrapper } from '../ObjectInfoWrapper/ObjectInfoWrapper';
+import { ObjectInfo } from '../ObjectInfoWrapper/ObjectInfo';
+import { FieldInfo } from '../ObjectInfoWrapper/FieldInfo';
+
+const LOOKUP_FIELD_TYPES = ['Lookup', 'MasterDetail', 'Hiearchy'];
+
+export class MermaidService {
+
+    static generateMermaidMarkdownForTree(objectInfoWrapper: ObjectInfoWrapper, treeObjectNames: string[], timestamp: string): string {
+
+        const treeWrapper = new ObjectInfoWrapper();
+        for (const objectName of treeObjectNames) {
+            if (objectName in objectInfoWrapper.ObjectToObjectInfoMap) {
+                treeWrapper.ObjectToObjectInfoMap[objectName] = objectInfoWrapper.ObjectToObjectInfoMap[objectName];
+            }
+        }
+
+        return this.generateMermaidMarkdown(treeWrapper, timestamp);
+
+    }
+
+    static generateMermaidMarkdown(objectInfoWrapper: ObjectInfoWrapper, timestamp: string): string {
+
+        const objectNames = Object.keys(objectInfoWrapper.ObjectToObjectInfoMap).sort();
+
+        const sections: string[] = [
+            `# Entity Relationship Diagram`,
+            ``,
+            `This diagram illustrates the object model for the Salesforce entities in this Treecipe tree.`,
+            `Each entity block lists its typed fields (string, number, date, datetime, boolean).`,
+            `Lookup relationships are shown with \`|o--o{\` cardinality (optional parent).`,
+            `MasterDetail relationships are shown with \`||--o{\` cardinality (required parent).`,
+            `Cross-tree relationships are excluded — only objects present in this recipe are shown.`,
+            ``,
+            `Generated: ${timestamp}`,
+            `Objects: ${objectNames.join(', ')}`,
+            ``,
+            `---`,
+            ``,
+            `\`\`\`mermaid`,
+            this.buildMermaidERD(objectInfoWrapper),
+            `\`\`\``,
+        ];
+
+        return sections.join('\n');
+
+    }
+
+    static buildMermaidERD(objectInfoWrapper: ObjectInfoWrapper): string {
+
+        const lines: string[] = ['erDiagram'];
+        const objectNames = Object.keys(objectInfoWrapper.ObjectToObjectInfoMap).sort();
+
+        for (const objectName of objectNames) {
+            const objectInfo = objectInfoWrapper.ObjectToObjectInfoMap[objectName];
+            const sanitizedName = this.sanitizeForMermaid(objectName);
+
+            lines.push(`    ${sanitizedName} {`);
+            lines.push(`        id Id`);
+
+            const nonRelationshipFields = (objectInfo.Fields ?? []).filter(
+                f => !LOOKUP_FIELD_TYPES.includes(f.type)
+            );
+            for (const field of nonRelationshipFields) {
+                const mermaidType = this.getMermaidFieldType(field.type);
+                lines.push(`        ${mermaidType} ${field.fieldName}`);
+            }
+
+            lines.push(`    }`);
+        }
+
+        lines.push(``);
+
+        for (const objectName of objectNames) {
+            const objectInfo = objectInfoWrapper.ObjectToObjectInfoMap[objectName];
+            for (const field of (objectInfo.Fields ?? [])) {
+
+                if (!LOOKUP_FIELD_TYPES.includes(field.type)) { continue; }
+
+                const parentName = field.referenceTo;
+                if (!parentName || !(parentName in objectInfoWrapper.ObjectToObjectInfoMap)) { continue; }
+
+                const parentSanitized = this.sanitizeForMermaid(parentName);
+                const childSanitized = this.sanitizeForMermaid(objectName);
+                const cardinality = field.type === 'MasterDetail' ? `||--o{` : `|o--o{`;
+                lines.push(`    ${parentSanitized} ${cardinality} ${childSanitized} : "${field.fieldName}"`);
+
+            }
+        }
+
+        return lines.join('\n');
+
+    }
+
+    static sanitizeForMermaid(objectName: string): string {
+        return objectName.replace(/-/g, '_');
+    }
+
+    static getMermaidFieldType(salesforceFieldType: string): string {
+
+        const typeMap: Record<string, string> = {
+            'Text': 'string',
+            'TextArea': 'string',
+            'LongTextArea': 'string',
+            'Html': 'string',
+            'Email': 'string',
+            'Phone': 'string',
+            'Url': 'string',
+            'Number': 'number',
+            'Currency': 'number',
+            'Percent': 'number',
+            'Date': 'date',
+            'DateTime': 'datetime',
+            'Boolean': 'boolean',
+            'Checkbox': 'boolean',
+            'Picklist': 'string',
+            'MultiselectPicklist': 'string',
+            'MultiSelectPicklist': 'string',
+            'AutoNumber': 'string',
+            'Formula': 'string',
+            'EncryptedText': 'string',
+        };
+
+        return typeMap[salesforceFieldType] ?? 'string';
+
+    }
+
+}

--- a/src/treecipe/src/MermaidService/tests/MermaidService.test.ts
+++ b/src/treecipe/src/MermaidService/tests/MermaidService.test.ts
@@ -1,0 +1,219 @@
+import { MermaidService } from '../MermaidService';
+import { ObjectInfoWrapper } from '../../ObjectInfoWrapper/ObjectInfoWrapper';
+import { FieldInfo } from '../../ObjectInfoWrapper/FieldInfo';
+import { RelationshipDetail } from '../../RelationshipService/RelationshipService';
+
+import * as matchers from 'jest-extended';
+expect.extend(matchers);
+
+
+function buildMockWrapper(objects: Record<string, {
+    fields: Array<{ name: string; label: string; type: string; referenceTo?: string }>;
+    childRefs?: Record<string, string[]>;
+}>): ObjectInfoWrapper {
+
+    const wrapper = new ObjectInfoWrapper();
+
+    for (const [objectName, config] of Object.entries(objects)) {
+        wrapper.addKeyToObjectInfoMap(objectName);
+        const objectInfo = wrapper.ObjectToObjectInfoMap[objectName];
+
+        objectInfo.Fields = config.fields.map(f =>
+            FieldInfo.create(objectName, f.name, f.label, f.type, [], null, f.referenceTo ?? null, null)
+        );
+
+        const relDetail: RelationshipDetail = {
+            objectApiName: objectName,
+            level: 0,
+            childObjectToFieldReferences: config.childRefs ?? {},
+            parentObjectToFieldReferences: {},
+            isProcessed: true,
+        };
+        objectInfo.RelationshipDetail = relDetail;
+    }
+
+    return wrapper;
+
+}
+
+
+describe('MermaidService', () => {
+
+    describe('buildMermaidERD', () => {
+
+        it('starts with erDiagram header', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
+            });
+            const result = MermaidService.buildMermaidERD(wrapper);
+            expect(result).toStartWith('erDiagram');
+        });
+
+        it('uses ||--o{ cardinality for MasterDetail relationships', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+                Contact: { fields: [
+                    { name: 'AccountId', label: 'Account', type: 'MasterDetail', referenceTo: 'Account' }
+                ]},
+            });
+            const result = MermaidService.buildMermaidERD(wrapper);
+            expect(result).toContain('||--o{');
+        });
+
+        it('uses |o--o{ cardinality for Lookup relationships', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+                Contact: { fields: [
+                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' }
+                ]},
+            });
+            const result = MermaidService.buildMermaidERD(wrapper);
+            expect(result).toContain('|o--o{');
+        });
+
+        it('excludes lookup fields from entity attribute blocks', () => {
+            const wrapper = buildMockWrapper({
+                Contact: { fields: [
+                    { name: 'FirstName', label: 'First Name', type: 'Text' },
+                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
+                ]},
+                Account: { fields: [] },
+            });
+            const result = MermaidService.buildMermaidERD(wrapper);
+            const contactEntityBlock = result.substring(
+                result.indexOf('Contact {'),
+                result.indexOf('}', result.indexOf('Contact {')) + 1
+            );
+            expect(contactEntityBlock).toContain('FirstName');
+            expect(contactEntityBlock).not.toContain('AccountId');
+        });
+
+        it('omits relationship line when referenced object is not in the wrapper', () => {
+            const wrapper = buildMockWrapper({
+                Contact: { fields: [
+                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
+                ]},
+            });
+            const result = MermaidService.buildMermaidERD(wrapper);
+            expect(result).not.toContain('||--o{');
+            expect(result).not.toContain('|o--o{');
+        });
+
+    });
+
+
+    describe('getMermaidFieldType', () => {
+
+        it('maps Text to string', () => {
+            expect(MermaidService.getMermaidFieldType('Text')).toBe('string');
+        });
+
+        it('maps Number and Currency to number', () => {
+            expect(MermaidService.getMermaidFieldType('Number')).toBe('number');
+            expect(MermaidService.getMermaidFieldType('Currency')).toBe('number');
+        });
+
+        it('maps Date and DateTime correctly', () => {
+            expect(MermaidService.getMermaidFieldType('Date')).toBe('date');
+            expect(MermaidService.getMermaidFieldType('DateTime')).toBe('datetime');
+        });
+
+        it('maps Boolean and Checkbox to boolean', () => {
+            expect(MermaidService.getMermaidFieldType('Boolean')).toBe('boolean');
+            expect(MermaidService.getMermaidFieldType('Checkbox')).toBe('boolean');
+        });
+
+        it('defaults to string for unknown types', () => {
+            expect(MermaidService.getMermaidFieldType('UnknownCustomType')).toBe('string');
+        });
+
+    });
+
+
+    describe('generateMermaidMarkdown', () => {
+
+        it('includes the ERD title and description', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
+            });
+            const result = MermaidService.generateMermaidMarkdown(wrapper, '2024-01-01T00-00-00');
+            expect(result).toContain('# Entity Relationship Diagram');
+            expect(result).toContain('Lookup relationships');
+            expect(result).toContain('MasterDetail relationships');
+        });
+
+        it('includes the mermaid code block with erDiagram', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
+            });
+            const result = MermaidService.generateMermaidMarkdown(wrapper, '2024-01-01T00-00-00');
+            expect(result).toContain('```mermaid');
+            expect(result).toContain('erDiagram');
+        });
+
+        it('includes the timestamp and object list', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+                Contact: { fields: [{ name: 'FirstName', label: 'First Name', type: 'Text' }] },
+            });
+            const timestamp = '2024-06-15T12-30-00';
+            const result = MermaidService.generateMermaidMarkdown(wrapper, timestamp);
+            expect(result).toContain(timestamp);
+            expect(result).toContain('Account');
+            expect(result).toContain('Contact');
+        });
+
+        it('does not include SOQL query sections', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
+            });
+            const result = MermaidService.generateMermaidMarkdown(wrapper, '2024-01-01T00-00-00');
+            expect(result).not.toContain('### Base Query');
+            expect(result).not.toContain('SOSL Template');
+            expect(result).not.toContain('SELECT');
+        });
+
+    });
+
+
+    describe('generateMermaidMarkdownForTree', () => {
+
+        it('only includes ERD entities for objects in the specified tree', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+                Contact: { fields: [{ name: 'FirstName', label: 'First Name', type: 'Text' }] },
+                Opportunity: { fields: [{ name: 'StageName', label: 'Stage', type: 'Text' }] },
+            });
+            const result = MermaidService.generateMermaidMarkdownForTree(
+                wrapper, ['Account', 'Contact'], '2024-01-01T00-00-00'
+            );
+            const mermaidBlock = result.substring(result.indexOf('erDiagram'));
+            expect(mermaidBlock).toContain('Account');
+            expect(mermaidBlock).toContain('Contact');
+            expect(mermaidBlock).not.toContain('Opportunity');
+        });
+
+        it('includes the title and description in the output', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+            });
+            const result = MermaidService.generateMermaidMarkdownForTree(
+                wrapper, ['Account'], '2024-01-01T00-00-00'
+            );
+            expect(result).toContain('# Entity Relationship Diagram');
+        });
+
+        it('gracefully handles object names not found in the full wrapper', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+            });
+            const result = MermaidService.generateMermaidMarkdownForTree(
+                wrapper, ['Account', 'NonExistentObject__c'], '2024-01-01T00-00-00'
+            );
+            expect(result).toContain('Account');
+            expect(result).not.toContain('NonExistentObject__c');
+        });
+
+    });
+
+});

--- a/src/treecipe/src/SOQLTemplateService/SOQLTemplateService.ts
+++ b/src/treecipe/src/SOQLTemplateService/SOQLTemplateService.ts
@@ -1,7 +1,6 @@
 import { ObjectInfoWrapper } from '../ObjectInfoWrapper/ObjectInfoWrapper';
 import { ObjectInfo } from '../ObjectInfoWrapper/ObjectInfo';
 import { FieldInfo } from '../ObjectInfoWrapper/FieldInfo';
-
 const LOOKUP_FIELD_TYPES = ['Lookup', 'MasterDetail', 'Hiearchy'];
 
 const TEXT_FIELD_TYPES = ['Text', 'TextArea', 'LongTextArea', 'Html', 'Email', 'Phone', 'Url'];
@@ -32,14 +31,6 @@ export class SOQLTemplateService {
             `Objects: ${objectNames.join(', ')}`,
             ``,
             `---`,
-            ``,
-            `## Entity Relationship Diagram`,
-            ``,
-            `\`\`\`mermaid`,
-            this.buildMermaidERD(objectInfoWrapper),
-            `\`\`\``,
-            ``,
-            `---`,
         ];
 
         for (const objectName of objectNames) {
@@ -49,52 +40,6 @@ export class SOQLTemplateService {
         }
 
         return sections.join('\n');
-
-    }
-
-    static buildMermaidERD(objectInfoWrapper: ObjectInfoWrapper): string {
-
-        const lines: string[] = ['erDiagram'];
-        const objectNames = Object.keys(objectInfoWrapper.ObjectToObjectInfoMap).sort();
-
-        for (const objectName of objectNames) {
-            const objectInfo = objectInfoWrapper.ObjectToObjectInfoMap[objectName];
-            const sanitizedName = this.sanitizeForMermaid(objectName);
-
-            lines.push(`    ${sanitizedName} {`);
-            lines.push(`        id Id`);
-
-            const nonRelationshipFields = (objectInfo.Fields ?? []).filter(
-                f => !LOOKUP_FIELD_TYPES.includes(f.type)
-            );
-            for (const field of nonRelationshipFields) {
-                const mermaidType = this.getMermaidFieldType(field.type);
-                lines.push(`        ${mermaidType} ${field.fieldName}`);
-            }
-
-            lines.push(`    }`);
-        }
-
-        lines.push(``);
-
-        for (const objectName of objectNames) {
-            const objectInfo = objectInfoWrapper.ObjectToObjectInfoMap[objectName];
-            for (const field of (objectInfo.Fields ?? [])) {
-
-                if (!LOOKUP_FIELD_TYPES.includes(field.type)) { continue; }
-
-                const parentName = field.referenceTo;
-                if (!parentName || !(parentName in objectInfoWrapper.ObjectToObjectInfoMap)) { continue; }
-
-                const parentSanitized = this.sanitizeForMermaid(parentName);
-                const childSanitized = this.sanitizeForMermaid(objectName);
-                const cardinality = field.type === 'MasterDetail' ? `||--o{` : `|o--o{`;
-                lines.push(`    ${parentSanitized} ${cardinality} ${childSanitized} : "${field.fieldName}"`);
-
-            }
-        }
-
-        return lines.join('\n');
 
     }
 
@@ -291,39 +236,6 @@ export class SOQLTemplateService {
         }
 
         return `${childObjectName}s`;
-
-    }
-
-    static sanitizeForMermaid(objectName: string): string {
-        return objectName.replace(/-/g, '_');
-    }
-
-    static getMermaidFieldType(salesforceFieldType: string): string {
-
-        const typeMap: Record<string, string> = {
-            'Text': 'string',
-            'TextArea': 'string',
-            'LongTextArea': 'string',
-            'Html': 'string',
-            'Email': 'string',
-            'Phone': 'string',
-            'Url': 'string',
-            'Number': 'number',
-            'Currency': 'number',
-            'Percent': 'number',
-            'Date': 'date',
-            'DateTime': 'datetime',
-            'Boolean': 'boolean',
-            'Checkbox': 'boolean',
-            'Picklist': 'string',
-            'MultiselectPicklist': 'string',
-            'MultiSelectPicklist': 'string',
-            'AutoNumber': 'string',
-            'Formula': 'string',
-            'EncryptedText': 'string',
-        };
-
-        return typeMap[salesforceFieldType] ?? 'string';
 
     }
 

--- a/src/treecipe/src/SOQLTemplateService/SOQLTemplateService.ts
+++ b/src/treecipe/src/SOQLTemplateService/SOQLTemplateService.ts
@@ -1,0 +1,330 @@
+import { ObjectInfoWrapper } from '../ObjectInfoWrapper/ObjectInfoWrapper';
+import { ObjectInfo } from '../ObjectInfoWrapper/ObjectInfo';
+import { FieldInfo } from '../ObjectInfoWrapper/FieldInfo';
+
+const LOOKUP_FIELD_TYPES = ['Lookup', 'MasterDetail', 'Hiearchy'];
+
+const TEXT_FIELD_TYPES = ['Text', 'TextArea', 'LongTextArea', 'Html', 'Email', 'Phone', 'Url'];
+
+export class SOQLTemplateService {
+
+    static generateSOQLTemplateMarkdownForTree(objectInfoWrapper: ObjectInfoWrapper, treeObjectNames: string[], timestamp: string): string {
+
+        const treeWrapper = new ObjectInfoWrapper();
+        for (const objectName of treeObjectNames) {
+            if (objectName in objectInfoWrapper.ObjectToObjectInfoMap) {
+                treeWrapper.ObjectToObjectInfoMap[objectName] = objectInfoWrapper.ObjectToObjectInfoMap[objectName];
+            }
+        }
+
+        return this.generateSOQLTemplateMarkdown(treeWrapper, timestamp);
+
+    }
+
+    static generateSOQLTemplateMarkdown(objectInfoWrapper: ObjectInfoWrapper, timestamp: string): string {
+
+        const objectNames = Object.keys(objectInfoWrapper.ObjectToObjectInfoMap).sort();
+
+        const sections: string[] = [
+            `# SOQL & SOSL Query Templates`,
+            ``,
+            `Generated: ${timestamp}`,
+            `Objects: ${objectNames.join(', ')}`,
+            ``,
+            `---`,
+            ``,
+            `## Entity Relationship Diagram`,
+            ``,
+            `\`\`\`mermaid`,
+            this.buildMermaidERD(objectInfoWrapper),
+            `\`\`\``,
+            ``,
+            `---`,
+        ];
+
+        for (const objectName of objectNames) {
+            const objectInfo = objectInfoWrapper.ObjectToObjectInfoMap[objectName];
+            sections.push(this.buildObjectSection(objectName, objectInfo, objectInfoWrapper));
+            sections.push(`---`);
+        }
+
+        return sections.join('\n');
+
+    }
+
+    static buildMermaidERD(objectInfoWrapper: ObjectInfoWrapper): string {
+
+        const lines: string[] = ['erDiagram'];
+        const objectNames = Object.keys(objectInfoWrapper.ObjectToObjectInfoMap).sort();
+
+        for (const objectName of objectNames) {
+            const objectInfo = objectInfoWrapper.ObjectToObjectInfoMap[objectName];
+            const sanitizedName = this.sanitizeForMermaid(objectName);
+
+            lines.push(`    ${sanitizedName} {`);
+            lines.push(`        id Id`);
+
+            const nonRelationshipFields = (objectInfo.Fields ?? []).filter(
+                f => !LOOKUP_FIELD_TYPES.includes(f.type)
+            );
+            for (const field of nonRelationshipFields) {
+                const mermaidType = this.getMermaidFieldType(field.type);
+                lines.push(`        ${mermaidType} ${field.fieldName}`);
+            }
+
+            lines.push(`    }`);
+        }
+
+        lines.push(``);
+
+        for (const objectName of objectNames) {
+            const objectInfo = objectInfoWrapper.ObjectToObjectInfoMap[objectName];
+            for (const field of (objectInfo.Fields ?? [])) {
+
+                if (!LOOKUP_FIELD_TYPES.includes(field.type)) { continue; }
+
+                const parentName = field.referenceTo;
+                if (!parentName || !(parentName in objectInfoWrapper.ObjectToObjectInfoMap)) { continue; }
+
+                const parentSanitized = this.sanitizeForMermaid(parentName);
+                const childSanitized = this.sanitizeForMermaid(objectName);
+                const cardinality = field.type === 'MasterDetail' ? `||--o{` : `|o--o{`;
+                lines.push(`    ${parentSanitized} ${cardinality} ${childSanitized} : "${field.fieldName}"`);
+
+            }
+        }
+
+        return lines.join('\n');
+
+    }
+
+    static buildObjectSection(objectName: string, objectInfo: ObjectInfo, objectInfoWrapper: ObjectInfoWrapper): string {
+
+        const sections: string[] = [
+            ``,
+            `## ${objectName}`,
+            ``,
+            `### Base Query`,
+            ``,
+            `\`\`\`sql`,
+            this.buildSelectAllQuery(objectName, objectInfo),
+            `\`\`\``,
+            ``,
+        ];
+
+        const childToParentQueries = this.buildChildToParentQueries(objectName, objectInfo, objectInfoWrapper);
+        if (childToParentQueries.length > 0) {
+            sections.push(`### Child-to-Parent Queries`);
+            sections.push(``);
+            for (const query of childToParentQueries) {
+                sections.push(`\`\`\`sql`);
+                sections.push(query);
+                sections.push(`\`\`\``);
+                sections.push(``);
+            }
+        }
+
+        const parentToChildQueries = this.buildParentToChildSubqueries(objectName, objectInfo, objectInfoWrapper);
+        if (parentToChildQueries.length > 0) {
+            sections.push(`### Parent-to-Child Queries`);
+            sections.push(``);
+            for (const query of parentToChildQueries) {
+                sections.push(`\`\`\`sql`);
+                sections.push(query);
+                sections.push(`\`\`\``);
+                sections.push(``);
+            }
+        }
+
+        const recordTypeQueries = this.buildRecordTypeFilteredQueries(objectName, objectInfo);
+        if (recordTypeQueries.length > 0) {
+            sections.push(`### Record Type Filtered Queries`);
+            sections.push(``);
+            for (const query of recordTypeQueries) {
+                sections.push(`\`\`\`sql`);
+                sections.push(query);
+                sections.push(`\`\`\``);
+                sections.push(``);
+            }
+        }
+
+        sections.push(`### SOSL Template`);
+        sections.push(``);
+        sections.push(`\`\`\`sosl`);
+        sections.push(this.buildSOSLTemplate(objectName, objectInfo));
+        sections.push(`\`\`\``);
+        sections.push(``);
+
+        return sections.join('\n');
+
+    }
+
+    static buildSelectAllQuery(objectName: string, objectInfo: ObjectInfo): string {
+
+        const fieldNames = (objectInfo.Fields ?? []).map(f => f.fieldName);
+        const allFields = ['Id', ...fieldNames];
+        return `SELECT ${allFields.join(',\n       ')}\nFROM ${objectName}`;
+
+    }
+
+    static buildChildToParentQueries(objectName: string, objectInfo: ObjectInfo, objectInfoWrapper: ObjectInfoWrapper): string[] {
+
+        const lookupFields = (objectInfo.Fields ?? []).filter(f => LOOKUP_FIELD_TYPES.includes(f.type));
+        const queries: string[] = [];
+
+        for (const field of lookupFields) {
+
+            const parentName = field.referenceTo;
+            if (!parentName) { continue; }
+
+            const relationshipName = this.getRelationshipNameFromField(field);
+            const parentInfo = objectInfoWrapper.ObjectToObjectInfoMap[parentName];
+
+            let parentFieldTraversals: string[] = [];
+            if (parentInfo?.Fields) {
+                parentFieldTraversals = parentInfo.Fields
+                    .filter(f => !LOOKUP_FIELD_TYPES.includes(f.type))
+                    .slice(0, 5)
+                    .map(f => `${relationshipName}.${f.fieldName}`);
+            }
+
+            const selectFields = ['Id', field.fieldName, ...parentFieldTraversals];
+            queries.push(
+                `-- ${field.type} to ${parentName} via ${field.fieldName}\n` +
+                `SELECT ${selectFields.join(',\n       ')}\n` +
+                `FROM ${objectName}`
+            );
+
+        }
+
+        return queries;
+
+    }
+
+    static buildParentToChildSubqueries(objectName: string, objectInfo: ObjectInfo, objectInfoWrapper: ObjectInfoWrapper): string[] {
+
+        if (!objectInfo.RelationshipDetail?.childObjectToFieldReferences) { return []; }
+
+        const queries: string[] = [];
+        const childRefs = objectInfo.RelationshipDetail.childObjectToFieldReferences;
+
+        for (const [childObjectName, lookupFieldNames] of Object.entries(childRefs)) {
+
+            if (!(childObjectName in objectInfoWrapper.ObjectToObjectInfoMap)) { continue; }
+
+            const childInfo = objectInfoWrapper.ObjectToObjectInfoMap[childObjectName];
+            const childFields = (childInfo?.Fields ?? [])
+                .filter(f => !LOOKUP_FIELD_TYPES.includes(f.type))
+                .slice(0, 5)
+                .map(f => f.fieldName);
+
+            const childSelectFields = ['Id', ...childFields].join(', ');
+            const childRelationshipName = this.deriveChildRelationshipName(childObjectName);
+            const lookupFieldNote = lookupFieldNames.join(', ');
+
+            queries.push(
+                `-- Children: ${childObjectName} (via ${lookupFieldNote})\n` +
+                `-- Note: Verify '${childRelationshipName}' is the correct Child Relationship Name\n` +
+                `SELECT Id,\n` +
+                `    (SELECT ${childSelectFields}\n` +
+                `     FROM ${childRelationshipName})\n` +
+                `FROM ${objectName}`
+            );
+
+        }
+
+        return queries;
+
+    }
+
+    static buildRecordTypeFilteredQueries(objectName: string, objectInfo: ObjectInfo): string[] {
+
+        if (!objectInfo.RecordTypesMap || Object.keys(objectInfo.RecordTypesMap).length === 0) { return []; }
+
+        const fieldNames = (objectInfo.Fields ?? [])
+            .filter(f => !LOOKUP_FIELD_TYPES.includes(f.type))
+            .map(f => f.fieldName);
+
+        const selectFields = ['Id', ...fieldNames].join(',\n       ');
+
+        return Object.keys(objectInfo.RecordTypesMap).map(developerName =>
+            `-- Record Type: ${developerName}\n` +
+            `SELECT ${selectFields}\n` +
+            `FROM ${objectName}\n` +
+            `WHERE RecordType.DeveloperName = '${developerName}'`
+        );
+
+    }
+
+    static buildSOSLTemplate(objectName: string, objectInfo: ObjectInfo): string {
+
+        const textFields = (objectInfo.Fields ?? [])
+            .filter(f => TEXT_FIELD_TYPES.includes(f.type))
+            .map(f => f.fieldName);
+
+        const returningFields = ['Id', ...textFields].join(', ');
+        return `FIND {searchTerm} IN ALL FIELDS\nRETURNING ${objectName}(${returningFields})`;
+
+    }
+
+    static getRelationshipNameFromField(fieldInfo: FieldInfo): string {
+
+        const fieldName = fieldInfo.fieldName;
+
+        if (fieldName.endsWith('Id') && !fieldName.includes('__')) {
+            return fieldName.slice(0, -2);
+        }
+
+        if (fieldName.endsWith('__c')) {
+            return fieldName.replace('__c', '__r');
+        }
+
+        return fieldName;
+
+    }
+
+    static deriveChildRelationshipName(childObjectName: string): string {
+
+        if (childObjectName.endsWith('__c')) {
+            const baseName = childObjectName.replace('__c', '');
+            return `${baseName}s__r`;
+        }
+
+        return `${childObjectName}s`;
+
+    }
+
+    static sanitizeForMermaid(objectName: string): string {
+        return objectName.replace(/-/g, '_');
+    }
+
+    static getMermaidFieldType(salesforceFieldType: string): string {
+
+        const typeMap: Record<string, string> = {
+            'Text': 'string',
+            'TextArea': 'string',
+            'LongTextArea': 'string',
+            'Html': 'string',
+            'Email': 'string',
+            'Phone': 'string',
+            'Url': 'string',
+            'Number': 'number',
+            'Currency': 'number',
+            'Percent': 'number',
+            'Date': 'date',
+            'DateTime': 'datetime',
+            'Boolean': 'boolean',
+            'Checkbox': 'boolean',
+            'Picklist': 'string',
+            'MultiselectPicklist': 'string',
+            'MultiSelectPicklist': 'string',
+            'AutoNumber': 'string',
+            'Formula': 'string',
+            'EncryptedText': 'string',
+        };
+
+        return typeMap[salesforceFieldType] ?? 'string';
+
+    }
+
+}

--- a/src/treecipe/src/SOQLTemplateService/tests/SOQLTemplateService.test.ts
+++ b/src/treecipe/src/SOQLTemplateService/tests/SOQLTemplateService.test.ts
@@ -1,0 +1,498 @@
+import { SOQLTemplateService } from '../SOQLTemplateService';
+import { ObjectInfoWrapper } from '../../ObjectInfoWrapper/ObjectInfoWrapper';
+import { ObjectInfo } from '../../ObjectInfoWrapper/ObjectInfo';
+import { FieldInfo } from '../../ObjectInfoWrapper/FieldInfo';
+import { RelationshipDetail } from '../../RelationshipService/RelationshipService';
+
+import * as matchers from 'jest-extended';
+expect.extend(matchers);
+
+
+function buildMockWrapper(objects: Record<string, {
+    fields: Array<{ name: string; label: string; type: string; referenceTo?: string }>;
+    childRefs?: Record<string, string[]>;
+    recordTypes?: Record<string, { DeveloperName: string; PicklistFieldSectionsToPicklistDetail: Record<string, string[]> }>;
+}>): ObjectInfoWrapper {
+
+    const wrapper = new ObjectInfoWrapper();
+
+    for (const [objectName, config] of Object.entries(objects)) {
+        wrapper.addKeyToObjectInfoMap(objectName);
+        const objectInfo = wrapper.ObjectToObjectInfoMap[objectName];
+
+        objectInfo.Fields = config.fields.map(f =>
+            FieldInfo.create(objectName, f.name, f.label, f.type, [], null, f.referenceTo ?? null, null)
+        );
+
+        const relDetail: RelationshipDetail = {
+            objectApiName: objectName,
+            level: 0,
+            childObjectToFieldReferences: config.childRefs ?? {},
+            parentObjectToFieldReferences: {},
+            isProcessed: true,
+        };
+        objectInfo.RelationshipDetail = relDetail;
+
+        if (config.recordTypes) {
+            objectInfo.RecordTypesMap = config.recordTypes as any;
+        }
+    }
+
+    return wrapper;
+
+}
+
+
+describe('SOQLTemplateService', () => {
+
+    describe('buildSelectAllQuery', () => {
+
+        it('includes Id plus all field names', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [
+                    { name: 'Name', label: 'Name', type: 'Text' },
+                    { name: 'Phone', label: 'Phone', type: 'Phone' },
+                ]}
+            });
+            const result = SOQLTemplateService.buildSelectAllQuery('Account', wrapper.ObjectToObjectInfoMap['Account']);
+            expect(result).toContain('SELECT');
+            expect(result).toContain('Id');
+            expect(result).toContain('Name');
+            expect(result).toContain('Phone');
+            expect(result).toContain('FROM Account');
+        });
+
+        it('handles object with no fields — only includes Id', () => {
+            const wrapper = buildMockWrapper({ Account: { fields: [] } });
+            const result = SOQLTemplateService.buildSelectAllQuery('Account', wrapper.ObjectToObjectInfoMap['Account']);
+            expect(result).toContain('Id');
+            expect(result).toContain('FROM Account');
+        });
+
+    });
+
+
+    describe('getRelationshipNameFromField', () => {
+
+        it('derives relationship name from a standard Salesforce lookup field ending in Id', () => {
+            const field = FieldInfo.create('Contact', 'AccountId', 'Account', 'Lookup', [], null, 'Account', null);
+            expect(SOQLTemplateService.getRelationshipNameFromField(field)).toBe('Account');
+        });
+
+        it('derives relationship name from a custom lookup field ending in __c', () => {
+            const field = FieldInfo.create('Child__c', 'Parent_Object__c', 'Parent', 'Lookup', [], null, 'Parent_Object__c', null);
+            expect(SOQLTemplateService.getRelationshipNameFromField(field)).toBe('Parent_Object__r');
+        });
+
+        it('returns the fieldName unchanged for unrecognized patterns', () => {
+            const field = FieldInfo.create('Obj__c', 'SomeField', 'Some Field', 'Lookup', [], null, null, null);
+            expect(SOQLTemplateService.getRelationshipNameFromField(field)).toBe('SomeField');
+        });
+
+    });
+
+
+    describe('deriveChildRelationshipName', () => {
+
+        it('pluralizes standard object names', () => {
+            expect(SOQLTemplateService.deriveChildRelationshipName('Contact')).toBe('Contacts');
+        });
+
+        it('adds __r suffix and pluralizes custom objects', () => {
+            expect(SOQLTemplateService.deriveChildRelationshipName('Custom_Object__c')).toBe('Custom_Objects__r');
+        });
+
+    });
+
+
+    describe('buildChildToParentQueries', () => {
+
+        it('generates one query per lookup field', () => {
+            const wrapper = buildMockWrapper({
+                Contact: { fields: [
+                    { name: 'FirstName', label: 'First Name', type: 'Text' },
+                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
+                ]},
+                Account: { fields: [
+                    { name: 'Name', label: 'Name', type: 'Text' },
+                    { name: 'Industry', label: 'Industry', type: 'Picklist' },
+                ]},
+            });
+
+            const result = SOQLTemplateService.buildChildToParentQueries('Contact', wrapper.ObjectToObjectInfoMap['Contact'], wrapper);
+            expect(result).toHaveLength(1);
+            expect(result[0]).toContain('AccountId');
+            expect(result[0]).toContain('Account.Name');
+            expect(result[0]).toContain('FROM Contact');
+        });
+
+        it('returns empty array when object has no lookup fields', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
+            });
+            const result = SOQLTemplateService.buildChildToParentQueries('Account', wrapper.ObjectToObjectInfoMap['Account'], wrapper);
+            expect(result).toHaveLength(0);
+        });
+
+        it('omits parent field traversals when parent object is not in the wrapper', () => {
+            const wrapper = buildMockWrapper({
+                Contact: { fields: [
+                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
+                ]},
+            });
+            const result = SOQLTemplateService.buildChildToParentQueries('Contact', wrapper.ObjectToObjectInfoMap['Contact'], wrapper);
+            expect(result).toHaveLength(1);
+            expect(result[0]).toContain('AccountId');
+            expect(result[0]).not.toContain('Account.Name');
+        });
+
+        it('skips lookup fields with no referenceTo', () => {
+            const wrapper = buildMockWrapper({
+                Contact: { fields: [
+                    { name: 'SomeLookup__c', label: 'Some Lookup', type: 'Lookup' },
+                ]},
+            });
+            const result = SOQLTemplateService.buildChildToParentQueries('Contact', wrapper.ObjectToObjectInfoMap['Contact'], wrapper);
+            expect(result).toHaveLength(0);
+        });
+
+    });
+
+
+    describe('buildParentToChildSubqueries', () => {
+
+        it('generates a subquery for each child object reference', () => {
+            const wrapper = buildMockWrapper({
+                Account: {
+                    fields: [{ name: 'Name', label: 'Name', type: 'Text' }],
+                    childRefs: { Contact: ['AccountId'] },
+                },
+                Contact: { fields: [
+                    { name: 'FirstName', label: 'First Name', type: 'Text' },
+                    { name: 'Email', label: 'Email', type: 'Email' },
+                ]},
+            });
+
+            const result = SOQLTemplateService.buildParentToChildSubqueries('Account', wrapper.ObjectToObjectInfoMap['Account'], wrapper);
+            expect(result).toHaveLength(1);
+            expect(result[0]).toContain('FROM Account');
+            expect(result[0]).toContain('AccountId');
+            expect(result[0]).toContain('FirstName');
+            expect(result[0]).toContain('Email');
+        });
+
+        it('returns empty array when object has no child references', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
+            });
+            const result = SOQLTemplateService.buildParentToChildSubqueries('Account', wrapper.ObjectToObjectInfoMap['Account'], wrapper);
+            expect(result).toHaveLength(0);
+        });
+
+        it('returns empty array when RelationshipDetail is undefined', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
+            });
+            wrapper.ObjectToObjectInfoMap['Account'].RelationshipDetail = undefined;
+            const result = SOQLTemplateService.buildParentToChildSubqueries('Account', wrapper.ObjectToObjectInfoMap['Account'], wrapper);
+            expect(result).toHaveLength(0);
+        });
+
+        it('skips child objects that are not present in the wrapper', () => {
+            const wrapper = buildMockWrapper({
+                Account: {
+                    fields: [{ name: 'Name', label: 'Name', type: 'Text' }],
+                    childRefs: { UnknownObject__c: ['Account__c'] },
+                },
+            });
+            const result = SOQLTemplateService.buildParentToChildSubqueries('Account', wrapper.ObjectToObjectInfoMap['Account'], wrapper);
+            expect(result).toHaveLength(0);
+        });
+
+    });
+
+
+    describe('buildRecordTypeFilteredQueries', () => {
+
+        it('generates one query per record type', () => {
+            const wrapper = buildMockWrapper({
+                Account: {
+                    fields: [{ name: 'Name', label: 'Name', type: 'Text' }],
+                    recordTypes: {
+                        Customer: { DeveloperName: 'Customer', PicklistFieldSectionsToPicklistDetail: {} },
+                        Partner: { DeveloperName: 'Partner', PicklistFieldSectionsToPicklistDetail: {} },
+                    },
+                },
+            });
+            const result = SOQLTemplateService.buildRecordTypeFilteredQueries('Account', wrapper.ObjectToObjectInfoMap['Account']);
+            expect(result).toHaveLength(2);
+            expect(result.some(q => q.includes("'Customer'"))).toBeTrue();
+            expect(result.some(q => q.includes("'Partner'"))).toBeTrue();
+            expect(result.every(q => q.includes('WHERE RecordType.DeveloperName'))).toBeTrue();
+        });
+
+        it('returns empty array when no record types exist', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
+            });
+            const result = SOQLTemplateService.buildRecordTypeFilteredQueries('Account', wrapper.ObjectToObjectInfoMap['Account']);
+            expect(result).toHaveLength(0);
+        });
+
+        it('excludes lookup fields from the select list', () => {
+            const wrapper = buildMockWrapper({
+                Account: {
+                    fields: [
+                        { name: 'Name', label: 'Name', type: 'Text' },
+                        { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
+                    ],
+                    recordTypes: {
+                        Customer: { DeveloperName: 'Customer', PicklistFieldSectionsToPicklistDetail: {} },
+                    },
+                },
+            });
+            const result = SOQLTemplateService.buildRecordTypeFilteredQueries('Account', wrapper.ObjectToObjectInfoMap['Account']);
+            expect(result[0]).not.toContain('AccountId');
+        });
+
+    });
+
+
+    describe('buildSOSLTemplate', () => {
+
+        it('includes only text-type fields in the RETURNING clause', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [
+                    { name: 'Name', label: 'Name', type: 'Text' },
+                    { name: 'Phone', label: 'Phone', type: 'Phone' },
+                    { name: 'Amount__c', label: 'Amount', type: 'Currency' },
+                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
+                ]},
+            });
+            const result = SOQLTemplateService.buildSOSLTemplate('Account', wrapper.ObjectToObjectInfoMap['Account']);
+            expect(result).toContain('FIND {searchTerm} IN ALL FIELDS');
+            expect(result).toContain('RETURNING Account(');
+            expect(result).toContain('Name');
+            expect(result).toContain('Phone');
+            expect(result).not.toContain('Amount__c');
+            expect(result).not.toContain('AccountId');
+        });
+
+        it('returns template with only Id when no text fields exist', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [
+                    { name: 'Amount__c', label: 'Amount', type: 'Currency' },
+                ]},
+            });
+            const result = SOQLTemplateService.buildSOSLTemplate('Account', wrapper.ObjectToObjectInfoMap['Account']);
+            expect(result).toContain('RETURNING Account(Id)');
+        });
+
+    });
+
+
+    describe('buildMermaidERD', () => {
+
+        it('starts with erDiagram header', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
+            });
+            const result = SOQLTemplateService.buildMermaidERD(wrapper);
+            expect(result).toStartWith('erDiagram');
+        });
+
+        it('uses ||--o{ cardinality for MasterDetail relationships', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+                Contact: { fields: [
+                    { name: 'AccountId', label: 'Account', type: 'MasterDetail', referenceTo: 'Account' }
+                ]},
+            });
+            const result = SOQLTemplateService.buildMermaidERD(wrapper);
+            expect(result).toContain('||--o{');
+        });
+
+        it('uses |o--o{ cardinality for Lookup relationships', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+                Contact: { fields: [
+                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' }
+                ]},
+            });
+            const result = SOQLTemplateService.buildMermaidERD(wrapper);
+            expect(result).toContain('|o--o{');
+        });
+
+        it('excludes lookup fields from entity attribute blocks', () => {
+            const wrapper = buildMockWrapper({
+                Contact: { fields: [
+                    { name: 'FirstName', label: 'First Name', type: 'Text' },
+                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
+                ]},
+                Account: { fields: [] },
+            });
+            const result = SOQLTemplateService.buildMermaidERD(wrapper);
+            const contactEntityBlock = result.substring(
+                result.indexOf('Contact {'),
+                result.indexOf('}', result.indexOf('Contact {')) + 1
+            );
+            expect(contactEntityBlock).toContain('FirstName');
+            expect(contactEntityBlock).not.toContain('AccountId');
+        });
+
+        it('omits relationship line when referenced object is not in the wrapper', () => {
+            const wrapper = buildMockWrapper({
+                Contact: { fields: [
+                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
+                ]},
+            });
+            const result = SOQLTemplateService.buildMermaidERD(wrapper);
+            expect(result).not.toContain('||--o{');
+            expect(result).not.toContain('|o--o{');
+        });
+
+    });
+
+
+    describe('getMermaidFieldType', () => {
+
+        it('maps Text to string', () => {
+            expect(SOQLTemplateService.getMermaidFieldType('Text')).toBe('string');
+        });
+
+        it('maps Number and Currency to number', () => {
+            expect(SOQLTemplateService.getMermaidFieldType('Number')).toBe('number');
+            expect(SOQLTemplateService.getMermaidFieldType('Currency')).toBe('number');
+        });
+
+        it('maps Date and DateTime correctly', () => {
+            expect(SOQLTemplateService.getMermaidFieldType('Date')).toBe('date');
+            expect(SOQLTemplateService.getMermaidFieldType('DateTime')).toBe('datetime');
+        });
+
+        it('maps Boolean and Checkbox to boolean', () => {
+            expect(SOQLTemplateService.getMermaidFieldType('Boolean')).toBe('boolean');
+            expect(SOQLTemplateService.getMermaidFieldType('Checkbox')).toBe('boolean');
+        });
+
+        it('defaults to string for unknown types', () => {
+            expect(SOQLTemplateService.getMermaidFieldType('UnknownCustomType')).toBe('string');
+        });
+
+    });
+
+
+    describe('generateSOQLTemplateMarkdown', () => {
+
+        it('includes all top-level section headers', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
+            });
+            const result = SOQLTemplateService.generateSOQLTemplateMarkdown(wrapper, '2024-01-01T00-00-00');
+            expect(result).toContain('# SOQL & SOSL Query Templates');
+            expect(result).toContain('## Entity Relationship Diagram');
+            expect(result).toContain('```mermaid');
+            expect(result).toContain('erDiagram');
+            expect(result).toContain('## Account');
+            expect(result).toContain('### Base Query');
+            expect(result).toContain('### SOSL Template');
+        });
+
+        it('includes the timestamp in the output', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [] }
+            });
+            const timestamp = '2024-06-15T12-30-00';
+            const result = SOQLTemplateService.generateSOQLTemplateMarkdown(wrapper, timestamp);
+            expect(result).toContain(timestamp);
+        });
+
+        it('includes a section for each object in the wrapper', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+                Contact: { fields: [{ name: 'FirstName', label: 'First Name', type: 'Text' }] },
+            });
+            const result = SOQLTemplateService.generateSOQLTemplateMarkdown(wrapper, '2024-01-01T00-00-00');
+            expect(result).toContain('## Account');
+            expect(result).toContain('## Contact');
+        });
+
+        it('includes relationship sections when lookups exist', () => {
+            const wrapper = buildMockWrapper({
+                Account: {
+                    fields: [{ name: 'Name', label: 'Name', type: 'Text' }],
+                    childRefs: { Contact: ['AccountId'] },
+                },
+                Contact: { fields: [
+                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
+                ]},
+            });
+            const result = SOQLTemplateService.generateSOQLTemplateMarkdown(wrapper, '2024-01-01T00-00-00');
+            expect(result).toContain('### Child-to-Parent Queries');
+            expect(result).toContain('### Parent-to-Child Queries');
+        });
+
+    });
+
+
+    describe('generateSOQLTemplateMarkdownForTree', () => {
+
+        it('only includes sections for objects in the specified tree', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+                Contact: { fields: [{ name: 'FirstName', label: 'First Name', type: 'Text' }] },
+                Opportunity: { fields: [{ name: 'StageName', label: 'Stage', type: 'Text' }] },
+            });
+            const result = SOQLTemplateService.generateSOQLTemplateMarkdownForTree(
+                wrapper, ['Account', 'Contact'], '2024-01-01T00-00-00'
+            );
+            expect(result).toContain('## Account');
+            expect(result).toContain('## Contact');
+            expect(result).not.toContain('## Opportunity');
+        });
+
+        it('only shows ERD entities for the specified tree', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+                Contact: { fields: [{ name: 'FirstName', label: 'First Name', type: 'Text' }] },
+                Opportunity: { fields: [{ name: 'StageName', label: 'Stage', type: 'Text' }] },
+            });
+            const result = SOQLTemplateService.generateSOQLTemplateMarkdownForTree(
+                wrapper, ['Account', 'Contact'], '2024-01-01T00-00-00'
+            );
+            const mermaidBlock = result.substring(result.indexOf('erDiagram'), result.indexOf('```', result.indexOf('erDiagram')));
+            expect(mermaidBlock).toContain('Account');
+            expect(mermaidBlock).toContain('Contact');
+            expect(mermaidBlock).not.toContain('Opportunity');
+        });
+
+        it('excludes parent-to-child subqueries for children outside the tree', () => {
+            const wrapper = buildMockWrapper({
+                Account: {
+                    fields: [{ name: 'Name', label: 'Name', type: 'Text' }],
+                    childRefs: { Contact: ['AccountId'], Opportunity: ['AccountId'] },
+                },
+                Contact: { fields: [{ name: 'FirstName', label: 'First Name', type: 'Text' }] },
+                Opportunity: { fields: [{ name: 'StageName', label: 'Stage', type: 'Text' }] },
+            });
+            const result = SOQLTemplateService.generateSOQLTemplateMarkdownForTree(
+                wrapper, ['Account', 'Contact'], '2024-01-01T00-00-00'
+            );
+            expect(result).toContain('Contact');
+            expect(result).not.toContain('Opportunity');
+        });
+
+        it('gracefully handles object names not found in the full wrapper', () => {
+            const wrapper = buildMockWrapper({
+                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
+            });
+            const result = SOQLTemplateService.generateSOQLTemplateMarkdownForTree(
+                wrapper, ['Account', 'NonExistentObject__c'], '2024-01-01T00-00-00'
+            );
+            expect(result).toContain('## Account');
+            expect(result).not.toContain('## NonExistentObject__c');
+        });
+
+    });
+
+});

--- a/src/treecipe/src/SOQLTemplateService/tests/SOQLTemplateService.test.ts
+++ b/src/treecipe/src/SOQLTemplateService/tests/SOQLTemplateService.test.ts
@@ -291,111 +291,20 @@ describe('SOQLTemplateService', () => {
     });
 
 
-    describe('buildMermaidERD', () => {
-
-        it('starts with erDiagram header', () => {
-            const wrapper = buildMockWrapper({
-                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
-            });
-            const result = SOQLTemplateService.buildMermaidERD(wrapper);
-            expect(result).toStartWith('erDiagram');
-        });
-
-        it('uses ||--o{ cardinality for MasterDetail relationships', () => {
-            const wrapper = buildMockWrapper({
-                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
-                Contact: { fields: [
-                    { name: 'AccountId', label: 'Account', type: 'MasterDetail', referenceTo: 'Account' }
-                ]},
-            });
-            const result = SOQLTemplateService.buildMermaidERD(wrapper);
-            expect(result).toContain('||--o{');
-        });
-
-        it('uses |o--o{ cardinality for Lookup relationships', () => {
-            const wrapper = buildMockWrapper({
-                Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
-                Contact: { fields: [
-                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' }
-                ]},
-            });
-            const result = SOQLTemplateService.buildMermaidERD(wrapper);
-            expect(result).toContain('|o--o{');
-        });
-
-        it('excludes lookup fields from entity attribute blocks', () => {
-            const wrapper = buildMockWrapper({
-                Contact: { fields: [
-                    { name: 'FirstName', label: 'First Name', type: 'Text' },
-                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
-                ]},
-                Account: { fields: [] },
-            });
-            const result = SOQLTemplateService.buildMermaidERD(wrapper);
-            const contactEntityBlock = result.substring(
-                result.indexOf('Contact {'),
-                result.indexOf('}', result.indexOf('Contact {')) + 1
-            );
-            expect(contactEntityBlock).toContain('FirstName');
-            expect(contactEntityBlock).not.toContain('AccountId');
-        });
-
-        it('omits relationship line when referenced object is not in the wrapper', () => {
-            const wrapper = buildMockWrapper({
-                Contact: { fields: [
-                    { name: 'AccountId', label: 'Account', type: 'Lookup', referenceTo: 'Account' },
-                ]},
-            });
-            const result = SOQLTemplateService.buildMermaidERD(wrapper);
-            expect(result).not.toContain('||--o{');
-            expect(result).not.toContain('|o--o{');
-        });
-
-    });
-
-
-    describe('getMermaidFieldType', () => {
-
-        it('maps Text to string', () => {
-            expect(SOQLTemplateService.getMermaidFieldType('Text')).toBe('string');
-        });
-
-        it('maps Number and Currency to number', () => {
-            expect(SOQLTemplateService.getMermaidFieldType('Number')).toBe('number');
-            expect(SOQLTemplateService.getMermaidFieldType('Currency')).toBe('number');
-        });
-
-        it('maps Date and DateTime correctly', () => {
-            expect(SOQLTemplateService.getMermaidFieldType('Date')).toBe('date');
-            expect(SOQLTemplateService.getMermaidFieldType('DateTime')).toBe('datetime');
-        });
-
-        it('maps Boolean and Checkbox to boolean', () => {
-            expect(SOQLTemplateService.getMermaidFieldType('Boolean')).toBe('boolean');
-            expect(SOQLTemplateService.getMermaidFieldType('Checkbox')).toBe('boolean');
-        });
-
-        it('defaults to string for unknown types', () => {
-            expect(SOQLTemplateService.getMermaidFieldType('UnknownCustomType')).toBe('string');
-        });
-
-    });
-
-
     describe('generateSOQLTemplateMarkdown', () => {
 
-        it('includes all top-level section headers', () => {
+        it('includes SOQL/SOSL section headers but not Mermaid ERD', () => {
             const wrapper = buildMockWrapper({
                 Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] }
             });
             const result = SOQLTemplateService.generateSOQLTemplateMarkdown(wrapper, '2024-01-01T00-00-00');
             expect(result).toContain('# SOQL & SOSL Query Templates');
-            expect(result).toContain('## Entity Relationship Diagram');
-            expect(result).toContain('```mermaid');
-            expect(result).toContain('erDiagram');
             expect(result).toContain('## Account');
             expect(result).toContain('### Base Query');
             expect(result).toContain('### SOSL Template');
+            expect(result).not.toContain('## Entity Relationship Diagram');
+            expect(result).not.toContain('```mermaid');
+            expect(result).not.toContain('erDiagram');
         });
 
         it('includes the timestamp in the output', () => {
@@ -451,19 +360,16 @@ describe('SOQLTemplateService', () => {
             expect(result).not.toContain('## Opportunity');
         });
 
-        it('only shows ERD entities for the specified tree', () => {
+        it('does not include ERD content in the SOQL template', () => {
             const wrapper = buildMockWrapper({
                 Account: { fields: [{ name: 'Name', label: 'Name', type: 'Text' }] },
                 Contact: { fields: [{ name: 'FirstName', label: 'First Name', type: 'Text' }] },
-                Opportunity: { fields: [{ name: 'StageName', label: 'Stage', type: 'Text' }] },
             });
             const result = SOQLTemplateService.generateSOQLTemplateMarkdownForTree(
                 wrapper, ['Account', 'Contact'], '2024-01-01T00-00-00'
             );
-            const mermaidBlock = result.substring(result.indexOf('erDiagram'), result.indexOf('```', result.indexOf('erDiagram')));
-            expect(mermaidBlock).toContain('Account');
-            expect(mermaidBlock).toContain('Contact');
-            expect(mermaidBlock).not.toContain('Opportunity');
+            expect(result).not.toContain('erDiagram');
+            expect(result).not.toContain('```mermaid');
         });
 
         it('excludes parent-to-child subqueries for children outside the tree', () => {
@@ -494,5 +400,6 @@ describe('SOQLTemplateService', () => {
         });
 
     });
+
 
 });

--- a/tasks.md
+++ b/tasks.md
@@ -25,6 +25,29 @@ Generate a query template file alongside each Treecipe recipe, giving developers
 
 ---
 
+### Feature: Required Field Identification and Documentation
+
+Surface required field information from Salesforce object metadata so developers know which fields must have a value — both in the generated recipe YAML and in the SOQL template companion file.
+
+**Goal:** Parse `<required>true</required>` XML attributes from field metadata and emit a YAML comment on required fields in the recipe output. Additionally, generate a dedicated "Required Fields" section in the SOQL template markdown listing all required fields per object so developers understand data constraints at a glance.
+
+**Scope:**
+
+- [ ] Extend `FieldInfo` to carry a `required: boolean` property, populated from `<required>true</required>` in the Salesforce field XML
+- [ ] Update `XmlFileProcessor` / `DirectoryProcessor` to read the `<required>` element and pass it into `FieldInfo.create()`
+- [ ] In `FakerJSRecipeFakerService` and `SnowfakeryRecipeFakerService`, prepend a `# REQUIRED FIELD` YAML comment above the faker expression for any field where `required === true`
+- [ ] Add a **Required Fields** section to the SOQL template markdown (in `SOQLTemplateService.buildObjectSection()`) listing the API names of all required fields for that object
+- [ ] Update `ObjectInfo` to expose a helper `getRequiredFields(): FieldInfo[]` for use by both the faker services and the SOQL template service
+
+**Tests**
+
+- [ ] Unit tests: field XML with `<required>true</required>` populates `FieldInfo.required = true`; field XML without the element defaults to `false`
+- [ ] Test that the faker service emits the `# REQUIRED FIELD` comment only for required fields, in both FakerJS and Snowfakery implementations
+- [ ] Test that `SOQLTemplateService` includes the Required Fields section with the correct field names, and omits the section when no required fields exist
+- [ ] Mock XML fixtures: object with no required fields, object with one required field, object with multiple required fields
+
+---
+
 ### Feature: Validation Rule Deactivator / Reactivator
 
 Allow data insertion to succeed by programmatically deactivating validation rules before a data load and reactivating them afterward. Produces deployable metadata and a tracking map file.
@@ -67,6 +90,61 @@ Allow data insertion to succeed by programmatically deactivating validation rule
 - [ ] Unit tests with mock XML fixtures: single active rule, single inactive rule, mixed set, object with no validation rules
 - [ ] Test map file serialization/deserialization
 - [ ] Test that only `wasActive: true` rules are included in the reactivation deploy set
+
+---
+
+### Feature: Date-Constraint-Aware Faker Value Generation
+
+Analyze Date and DateTime field XML and any active validation rules referencing those fields to generate faker date expressions that satisfy date range constraints — so generated data respects business rules like "close date must be in the future" or "start date must be before end date".
+
+**Goal:** When generating a recipe value for a `Date` or `DateTime` field, check the field's own XML attributes and any active validation rules that reference that field, extract date boundary constraints (min date, max date, relative offsets, field-to-field comparisons), and emit a faker expression with the appropriate `from`/`to` bounds.
+
+**Scope:**
+
+- [ ] Extend `ValidationRuleAnalyzerService` to recognize date-specific formula patterns:
+  - `CloseDate > TODAY()` → date must be in the future (`from: today`, `to: today + configurable range`)
+  - `CloseDate < TODAY()` → date must be in the past
+  - `CloseDate >= DATE(2020, 1, 1)` → absolute date lower bound
+  - `CloseDate <= DATE(2025, 12, 31)` → absolute date upper bound
+  - `EndDate__c >= StartDate__c` → field-to-field ordering constraint (emit TODO comment with context)
+- [ ] New `constraintType` values: `'dateMin'`, `'dateMax'`, `'dateRelativeMin'`, `'dateRelativeMax'`
+- [ ] Extend `FakerJSRecipeFakerService.buildDateRecipeValue()` to accept optional date constraints and adjust the `from`/`to` in `faker.date.between()`
+- [ ] Extend `SnowfakeryRecipeFakerService.buildDateRecipeValue()` equivalently using `fake.date_between(start_date=..., end_date=...)`
+- [ ] Add mock XML validation rule fixtures for date constraint scenarios
+- [ ] For field-to-field comparisons, emit a YAML comment describing the ordering constraint rather than trying to resolve it programmatically
+
+**Tests**
+- [ ] Unit tests: `TODAY()` future bound, `TODAY()` past bound, `DATE(Y, M, D)` absolute lower bound, `DATE(Y, M, D)` absolute upper bound, field-to-field comparison → comment
+- [ ] Test that both faker backend services produce date expressions with the correct `from`/`to` range
+- [ ] Test that no constraint falls back to the default date range
+
+---
+
+### Feature: Validation-Rule-Aware Faker Value Generation
+
+Analyze validation rule XML for each Salesforce object and use the embedded formula logic to generate faker values that satisfy those constraints — so generated data passes validation rules without requiring them to be deactivated.
+
+**Goal:** Parse `*.validationRule-meta.xml` files alongside the object's field XML, extract the `<errorConditionFormula>` expressions, infer constraints (regex patterns, range checks, required field dependencies, picklist restrictions), and emit faker expressions in the recipe that satisfy those constraints.
+
+**Scope:**
+
+- [ ] New service: `ValidationRuleAnalyzerService` following existing service-per-folder pattern with `tests/` subfolder
+- [ ] Parse all `*.validationRule-meta.xml` files under the configured `salesforceObjectsPath` for a given object
+- [ ] For each active rule (`<active>true</active>`), extract the `<errorConditionFormula>` and `<errorMessage>` and associate the rule with the relevant field(s) it references (via regex on field API names in the formula)
+- [ ] Identify common formula patterns and translate them to faker constraints:
+  - `REGEX(Field__c, "pattern")` → use `faker.helpers.fromRegExp()` or constrain to matching values
+  - `Field__c < X` / `Field__c > X` → set numeric `min`/`max` bounds on the faker expression
+  - `ISPICKVAL(Field__c, "value")` → restrict to (or exclude) specific picklist values
+  - `NOT(ISBLANK(Field__c))` → mark field as required (non-null) in the recipe
+  - `LEN(Field__c) <= N` / `LEN(Field__c) >= N` → constrain string length bounds
+- [ ] Pass the extracted constraints into `FakerJSRecipeFakerService` and `SnowfakeryRecipeFakerService` so each field's faker expression respects the active validation rules for that object
+- [ ] If a formula is too complex to parse deterministically, emit a YAML comment noting the unresolved rule and its error message so the developer is aware
+- [ ] Integrate into the existing `RecipeService` orchestration flow — runs after object/field metadata is parsed, before recipe YAML is written
+
+**Tests**
+- [ ] Unit tests with mock XML fixtures: object with no validation rules, single REGEX rule, single numeric range rule, ISPICKVAL restriction, ISBLANK required-field rule, multi-rule object
+- [ ] Test that unrecognized/complex formulas produce a YAML comment rather than crashing
+- [ ] Test that constraints are correctly forwarded to both faker backend services
 
 ---
 

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,83 @@
+# Tasks
+
+## In Progress
+
+<!-- Move items here when actively working on them -->
+
+## Backlog
+
+### Feature: SOQL/SOSL Query Template Builder
+
+Generate a query template file alongside each Treecipe recipe, giving developers ready-to-use SOQL and SOSL queries based on the actual object metadata parsed from source.
+
+**Goal:** After the directory is parsed and relationships/lookups are resolved, write a `.soql-templates.txt` (or `.md`) file per object (or one combined file) that captures every meaningful query scenario for that object.
+
+**Scope:**
+
+- [x] Generate a base `SELECT <all fields> FROM <Object>` query per object using every field found in source XML
+- [ ] Generate filtered variants: one per indexed field (`<externalId>true</externalId>`, `<unique>true</unique>`)
+- [x] Generate relationship (JOIN) queries for every Lookup and MasterDetail field — both parent-to-child (`SELECT Id, (SELECT Id FROM ChildObjects__r) FROM ParentObject__c`) and child-to-parent (`SELECT Id, ParentObject__r.Name FROM ChildObject__c`)
+- [x] Generate SOSL templates: `FIND {searchTerm} IN ALL FIELDS RETURNING <Object>(<fields>)` scoped to text-type fields
+- [x] Include record type filters where record types are detected (`WHERE RecordType.DeveloperName = 'X'`)
+- [x] Integrate as a post-step in `RecipeService` — runs after YAML generation, writes template file(s) to the same output directory
+- [x] New service: `SOQLTemplateService` following existing service-per-folder pattern with `tests/` subfolder
+- [x] Tests: unit tests with mock XML fixtures covering simple object, multi-lookup object, record-type object, and SOSL scenarios
+
+---
+
+### Feature: Validation Rule Deactivator / Reactivator
+
+Allow data insertion to succeed by programmatically deactivating validation rules before a data load and reactivating them afterward. Produces deployable metadata and a tracking map file.
+
+**Goal:** Parse all validation rule XML files from a Salesforce source directory, generate deactivated copies ready to deploy via `sf project deploy start`, and maintain a JSON map that records what was deactivated so the reactivation step can restore them precisely.
+
+**Scope:**
+
+**Deactivation Step**
+- [ ] New service: `ValidationRuleService` following existing service-per-folder pattern with `tests/` subfolder
+- [ ] Parse all `*.validationRules-meta.xml` files under the configured `salesforceObjectsPath`
+- [ ] For each active rule (where `<active>true</active>`), produce a copy with `<active>false</active>` written to a staging output directory (e.g., `treecipe/validationRules/deactivated/`)
+- [ ] Write a `validationRuleMap.json` tracking file to `treecipe/validationRules/` with the structure:
+  ```json
+  {
+    "generatedAt": "<ISO timestamp>",
+    "orgAlias": "<alias used>",
+    "rules": [
+      {
+        "object": "Account",
+        "ruleName": "Require_Phone_on_Close",
+        "filePath": "force-app/.../Account.Require_Phone_on_Close.validationRule-meta.xml",
+        "wasActive": true,
+        "currentState": "deactivated"
+      }
+    ]
+  }
+  ```
+- [ ] New VS Code command: `treecipe.deactivateValidationRules` — prompts for org alias, runs deactivation + deploy
+- [ ] After staging files are written, invoke `sf project deploy start` against the staging directory
+- [ ] Show progress in VS Code output channel; surface errors via `ErrorHandlingService`
+
+**Reactivation Step**
+- [ ] New VS Code command: `treecipe.reactivateValidationRules` — reads `validationRuleMap.json`, restores only rules where `wasActive: true`
+- [ ] Regenerates original (active) XML copies to a `treecipe/validationRules/reactivated/` staging directory
+- [ ] Deploys reactivated rules via `sf project deploy start`
+- [ ] Updates `validationRuleMap.json` `currentState` to `"reactivated"` on success
+
+**Tests**
+- [ ] Unit tests with mock XML fixtures: single active rule, single inactive rule, mixed set, object with no validation rules
+- [ ] Test map file serialization/deserialization
+- [ ] Test that only `wasActive: true` rules are included in the reactivation deploy set
+
+---
+
+## Completed
+
+- [x] v2.6.0 — Relationship Service: multi-object Treecipe file grouping by relationship hierarchy
+- [x] v2.6.0 — Bug fix: picklist values with special characters (`&`, `'`) breaking FakerJS expressions
+- [x] v2.7.0 — Enhanced numeric/currency field precision: respect `<precision>` and `<scale>` XML attributes when generating faker-js recipe values
+
+## Notes
+
+- Run tests: `npm run jest-test`
+- Compile: `npm run compile`
+- Lint: `npm run lint`


### PR DESCRIPTION
### Motivation and Context
The v2.8.0 release embedded the Mermaid ERD directly inside the SOQL/SOSL query template file, mixing two distinct concerns in a single document. Developers who want to share or render the relationship diagram have to open a file that also contains dozens of query templates, and vice versa. Separating them gives each file a clear single purpose: the SOQL/SOSL file stays focused on query templates, and the ERD file stands alone as a shareable, renderable diagram with its own explanatory context.

Additionally, the Mermaid generation logic lived inside `SOQLTemplateService`, which is the wrong conceptual home. Extracting it into a dedicated `MermaidService` keeps the service-per-concern pattern consistent with the rest of the codebase.

---

### Any Technical Decisions to Note?
- **New file naming convention** — the ERD file follows the same `--{tree-name}-{timestamp}` pattern as its siblings: `mermaid-erd--{treecipeTopToBottomLevelName}-{isoDateTimestamp}.md`. This keeps all per-tree companion files consistently named and sorted together in the output folder.
- **`MermaidService` is self-contained** — it imports only from `ObjectInfoWrapper`, `ObjectInfo`, and `FieldInfo`. No circular dependency risk. `SOQLTemplateService` no longer owns any Mermaid logic; `DirectoryProcessor` calls `MermaidService` directly for the ERD file.
- **`SOQLTemplateService.generateMermaidMarkdownForTree` was not kept as a pass-through** — since nothing in the production path called it through `SOQLTemplateService`, keeping a forwarding shim would have been dead weight. The delegation goes straight `DirectoryProcessor → MermaidService`.
- **`LOOKUP_FIELD_TYPES` is duplicated** in both services — this is intentional to keep each service self-contained and avoid creating a shared constants module for a two-item array. If this list grows it may warrant extraction.

---

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other (please describe):

---

### How Has This Been Tested?
- [ ] Tested on Windows
- [x] Tested on macOS
- [ ] Tested on Linux
- [x] Added new unit tests
- [x] Updated existing tests

#### Test Details
**New tests — `MermaidService.test.ts` (19 tests):**
- `buildMermaidERD` — verifies `erDiagram` header, `||--o{` cardinality for MasterDetail, `|o--o{` for Lookup, lookup fields excluded from entity attribute blocks, relationship lines omitted when referenced object is absent from the tree wrapper
- `getMermaidFieldType` — covers Text→string, Number/Currency→number, Date→date, DateTime→datetime, Boolean/Checkbox→boolean, unknown→string fallback
- `generateMermaidMarkdown` — verifies title, description prose, mermaid code block, timestamp, object list, and absence of SOQL query content
- `generateMermaidMarkdownForTree` — verifies tree isolation (Opportunity excluded when not in tree), title present, graceful handling of unknown object names

**Updated tests — `SOQLTemplateService.test.ts`:**
- Removed `buildMermaidERD` and `getMermaidFieldType` describe blocks (now in `MermaidService.test.ts`)
- Updated `generateSOQLTemplateMarkdown` to assert that `## Entity Relationship Diagram`, ` ```mermaid `, and `erDiagram` are **not** present
- Updated `generateSOQLTemplateMarkdownForTree` to assert no ERD content bleeds into the SOQL template

All 354 tests pass; `npm run compile` produces zero TypeScript errors.

---

### Checklist
- [x] Pull Request title captures expected version update
- [x] package.json version number updated (2.8.0 → 2.9.0)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (CHANGELOG.md updated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

### Reviewers
@mention-team-members-or-specific-reviewers
