### PR TITLE
feat: add Claude Code project slash commands for VS Code extension workflow

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -1,0 +1,258 @@
+---
+name: code-review
+description: Triple code review — senior TS engineer (architecture, type safety, service patterns, dual-backend sync), senior perf engineer (activation time, XML processing), and senior security engineer (injection, CI/CD, supply chain) run in parallel.
+---
+
+## Triple Review — Three Reviewers in Parallel
+
+This skill runs **three independent code reviews in parallel** using the Agent tool:
+
+1. **Senior TypeScript Engineer** — architecture, type safety, service class patterns, dual-backend sync, test coverage
+2. **Senior Performance Engineer** — extension activation time, XML processing performance, memory use (the review below)
+3. **Senior Security Engineer** — invoke `/security-review`
+
+Launch all three as parallel agents. Each independently determines changed files, reads them, and produces its own report. After all complete, present the three reports sequentially — architecture first, then performance, then security.
+
+**PR comments:** If a PR exists, each review posts its own comment to the PR — three separate comments, clearly labeled.
+
+---
+
+## Pre-Review: Commit & Push Gate
+
+Before reviewing, ensure everything is committed and pushed:
+
+```bash
+git status
+git log --oneline -5
+```
+
+If there are uncommitted changes, ask the user whether to commit them before proceeding.
+
+---
+
+## Senior TypeScript Engineer Review
+
+You are a senior TypeScript engineer reviewing code for Salesforce Data Treecipe (VS Code Extension). Review all changed files against CLAUDE.md architecture standards and report issues by severity.
+
+### Determine Changed Files
+
+```bash
+git diff main...HEAD --name-only 2>/dev/null || git diff HEAD~1 --name-only
+```
+
+Read each changed `.ts` file. For context on unchanged files they interact with, read those too.
+
+---
+
+### Check 1 — TypeScript Strict Mode [CRITICAL if violated]
+
+```bash
+npm run compile 2>&1
+```
+
+Zero errors required. Also grep for `any` usage:
+
+```bash
+git diff main...HEAD -- '*.ts' | grep "^+" | grep -v "^+++" | grep ": any\|as any" || true
+```
+
+**Flag:** Any implicit or explicit `any` in non-test files as **[HIGH]** — CLAUDE.md requires strict TypeScript with no implicit `any`.
+
+---
+
+### Check 2 — Service Class Pattern [HIGH if violated]
+
+All services must be classes with `static` methods. No standalone exported functions outside a class.
+
+```bash
+git diff main...HEAD -- '*.ts' | grep "^+export function\|^+export const.*=.*=>" | grep -v "^+++" | grep -v "\.test\.ts" || true
+```
+
+**Flag:** Exported functions/arrow functions outside a class in service files.
+
+---
+
+### Check 3 — Interface Conformance [CRITICAL if violated]
+
+If any `FakerJSRecipeFakerService` or `SnowfakeryRecipeFakerService` files changed, verify both still implement `IRecipeFakerService` correctly:
+
+```bash
+grep -n "implements\|IRecipeFakerService\|IFakerRecipeProcessor" src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts || true
+grep -n "implements\|IRecipeFakerService\|IFakerRecipeProcessor" src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts || true
+```
+
+---
+
+### Check 4 — Dual Backend Parity [CRITICAL if violated]
+
+Per CLAUDE.md: every field type handler added to FakerJS must have an equivalent in Snowfakery. Check for parity:
+
+```bash
+grep -c "case '" src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts 2>/dev/null || true
+grep -c "case '" src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts 2>/dev/null || true
+```
+
+If counts differ, read both files and list the missing handlers.
+
+---
+
+### Check 5 — Test Coverage [HIGH if missing]
+
+Every changed service file must have a corresponding updated test file:
+
+```bash
+git diff main...HEAD --name-only | grep "\.ts$" | grep -v "\.test\.ts" | grep "src/treecipe/" | while read f; do
+  testDir=$(dirname "$f")/tests
+  echo "Service: $f — Test dir: $testDir"
+  ls "$testDir" 2>/dev/null || echo "  WARNING: No tests directory found"
+done
+```
+
+**Flag:** Any service file changed without a corresponding test file update as **[HIGH]**.
+
+---
+
+### Check 6 — Precision/Scale Math [HIGH if wrong]
+
+For any changes to numeric or currency field handling, verify the math:
+- `left_digits = precision - scale`
+- `max = 10^left_digits - 1`
+- `dec = scale`
+
+Grep for precision/scale usage:
+
+```bash
+git diff main...HEAD -- '*.ts' | grep "^+" | grep -v "^+++" | grep -i "precision\|scale\|leftDigit" || true
+```
+
+---
+
+### Check 7 — Picklist Special Character Escaping [HIGH if missing]
+
+Picklist values containing `&`, `'`, `"`, `<`, `>` must be escaped before embedding in faker expressions. Check any picklist-related changes:
+
+```bash
+git diff main...HEAD -- '*.ts' | grep "^+" | grep -v "^+++" | grep -i "picklist\|valueSet\|globalValue" || true
+```
+
+---
+
+### Check 8 — Tests Pass
+
+```bash
+npm run jest-test 2>&1 | tail -15
+```
+
+All tests must pass.
+
+---
+
+### Architecture Review Output Format
+
+```
+## 🔍 Code Review — Senior TypeScript Engineer
+
+### Summary
+<1-2 sentence overview of what changed and overall assessment>
+
+### Findings
+
+| Severity | Location | Issue |
+|----------|----------|-------|
+| [CRITICAL/HIGH/MEDIUM/LOW] | file.ts:line | description |
+
+### Dual Backend Parity
+PASS — FakerJS: N handlers, Snowfakery: N handlers (matching)
+  OR
+FAIL — FakerJS has X, Snowfakery missing: <list>
+
+### Test Coverage
+PASS — all changed services have updated tests
+  OR
+HIGH — <service> changed but no test update found
+
+### Verdict
+APPROVE — no blocking issues
+  OR
+REQUEST CHANGES — <N> critical/high issues require fixes
+```
+
+---
+
+## Senior Performance Engineer Review
+
+You are a senior performance engineer reviewing Salesforce Data Treecipe (VS Code Extension) for runtime performance issues. The key concern: this extension processes potentially large Salesforce org metadata directories (hundreds of object XML files, each with many fields). Performance problems cause the extension to feel slow or unresponsive.
+
+### Determine Changed Files
+
+```bash
+git diff main...HEAD --name-only | grep -E "\.ts$" | grep -v "\.test\.ts"
+```
+
+Read each changed file.
+
+### Perf Check 1 — Extension Activation Cost
+
+Read `src/extension.ts`. Check that `activate()` does minimal work at startup:
+- Should only register commands, not execute them
+- Should not parse any files, walk directories, or make network calls
+- Any heavy initialization should be deferred until the command is actually invoked
+
+### Perf Check 2 — Synchronous File I/O
+
+```bash
+git diff main...HEAD -- '*.ts' | grep "^+" | grep -v "^+++" | grep "readFileSync\|readdirSync\|existsSync\|writeFileSync" || true
+```
+
+Synchronous file operations block the VS Code UI thread. In command handlers processing many files, these should be `async`/`await` with their async equivalents.
+
+**Flag:** Any synchronous file I/O in the main command path (not in tests or config reads) as **[HIGH]**.
+
+### Perf Check 3 — Large Directory Processing
+
+Read `src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts`. Check:
+- Does it stream/chunk results or load everything into memory?
+- Is there any short-circuiting for malformed/unexpected files?
+- Does it report progress to VS Code's Progress API for long-running operations?
+
+### Perf Check 4 — XML Parsing
+
+Review any changed XML parsing code. `xml2js.parseStringPromise` is async — verify it is awaited and not called synchronously in a tight loop.
+
+### Perf Check 5 — String Concatenation at Scale
+
+Recipe YAML generation loops over hundreds of fields. Check for string concatenation patterns that allocate large numbers of intermediate strings:
+
+```bash
+git diff main...HEAD -- '*.ts' | grep "^+" | grep -v "^+++" | grep 'result \+= \|output \+= ' || true
+```
+
+Prefer array push + join over repeated string concatenation in loops.
+
+### Perf Review Output Format
+
+```
+## ⚡ Performance Review — Senior Performance Engineer
+
+### Summary
+<what changed and performance risk level>
+
+### Findings
+| Severity | Location | Issue |
+|----------|----------|-------|
+
+### Verdict
+APPROVE — no performance concerns
+  OR
+REQUEST CHANGES — <issue>
+```
+
+---
+
+## Post Both Reviews to PR
+
+```bash
+gh pr view --json number 2>/dev/null --jq '.number'
+```
+
+If a PR exists, post each review as a separate comment. Then run `/pr-body` to update the PR table of contents.

--- a/.claude/commands/contract-test.md
+++ b/.claude/commands/contract-test.md
@@ -1,0 +1,175 @@
+---
+name: contract-test
+description: Verifies that both faker backends implement IRecipeFakerService and IFakerRecipeProcessor identically — same field type handlers, same method signatures, same return shapes. Run after changing any faker service.
+---
+
+# /contract-test — Faker Backend Interface Verification
+
+Contract tests verify that **FakerJSRecipeFakerService** and **SnowfakeryRecipeFakerService** agree on the same field type handling contract. They catch the #1 source of drift in this codebase: a handler added to one backend but not the other.
+
+## When to Use
+
+- After adding a new Salesforce field type handler to either backend
+- After changing a method signature in `IRecipeFakerService` or `IFakerRecipeProcessor`
+- After any refactor of the faker service classes
+- As part of a pre-merge check
+
+---
+
+## Step 1 — Read the Interfaces
+
+Read both interface files to understand the contract:
+
+```bash
+cat src/treecipe/src/RecipeFakerService.ts/IRecipeFakerService.ts
+cat src/treecipe/src/FakerRecipeProcessor/IFakerRecipeProcessor.ts
+```
+
+Document every method signature that both implementations must provide.
+
+---
+
+## Step 2 — Verify Interface Implementation Declarations
+
+Both service classes must declare `implements`:
+
+```bash
+grep -n "implements\|class Faker" src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts
+grep -n "implements\|class Snowfakery" src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts
+```
+
+**Flag:** Either class missing `implements IRecipeFakerService` as **[CRITICAL]**.
+
+---
+
+## Step 3 — Method Signature Parity
+
+For each method defined in `IRecipeFakerService`, verify both implementations have the exact same parameter names, types, and return types:
+
+```bash
+grep -n "static\|public\|private" src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts | grep -v "\.test\." | head -40
+grep -n "static\|public\|private" src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts | grep -v "\.test\." | head -40
+```
+
+---
+
+## Step 4 — Field Type Handler Parity
+
+This is the most critical check. Both backends must handle the same set of Salesforce field types.
+
+Extract the field type keys from each backend:
+
+```bash
+echo "=== FakerJS field types ==="
+grep -oE "'[A-Za-z]+':" src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts | sort -u
+
+echo "=== Snowfakery field types ==="
+grep -oE "'[A-Za-z]+':" src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts | sort -u
+```
+
+Or extract `case` statements if using a switch:
+
+```bash
+echo "=== FakerJS cases ==="
+grep "case " src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts | sed "s/.*case //" | sed "s/:.*//" | sort -u
+
+echo "=== Snowfakery cases ==="
+grep "case " src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts | sed "s/.*case //" | sed "s/:.*//" | sort -u
+```
+
+Diff the two sets. Any field type in one but not the other is a **[CRITICAL]** contract violation.
+
+---
+
+## Step 5 — Return Shape Contracts
+
+For a sample of field type handlers in each backend, verify the return shape is consistent with what `RecipeService` / `FakerRecipeProcessor` consumes. Read the caller:
+
+```bash
+grep -n "getRecipeFor\|getFakerExpression\|processField" src/treecipe/src/RecipeService/RecipeService.ts 2>/dev/null | head -20 || true
+```
+
+Verify the shape of values consumed from faker service methods matches what both implementations return.
+
+---
+
+## Step 6 — Run Existing Tests
+
+```bash
+npm run jest-test 2>&1 | tail -20
+```
+
+If any faker service tests are failing, report them as **[CRITICAL]** — they indicate a contract violation that was already caught.
+
+---
+
+## Step 7 — Add Missing Contract Tests
+
+If field type handler parity gaps were found, add or update countermeasure tests for each backend:
+
+**Test pattern for a field type handler contract:**
+
+```typescript
+describe('contract: <FieldType> handler', () => {
+  it('FakerJS produces a non-empty string for <FieldType>', () => {
+    const result = FakerJSRecipeFakerService.getRecipeFor<FieldType>(...);
+    expect(result).toBeTruthy();
+    expect(typeof result).toBe('string');
+  });
+
+  it('Snowfakery produces a non-empty string for <FieldType>', () => {
+    const result = SnowfakeryRecipeFakerService.getRecipeFor<FieldType>(...);
+    expect(result).toBeTruthy();
+    expect(typeof result).toBe('string');
+  });
+});
+```
+
+Test placement:
+- FakerJS: `src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/tests/`
+- Snowfakery: `src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/tests/`
+
+---
+
+## Step 8 — Report
+
+```
+## Contract Test Report — Faker Backend Interfaces
+
+### Interface Implementation
+| Class | Implements IRecipeFakerService | Status |
+|-------|-------------------------------|--------|
+| FakerJSRecipeFakerService | Yes | ✅ |
+| SnowfakeryRecipeFakerService | Yes | ✅ |
+
+### Method Signature Parity
+| Method | FakerJS | Snowfakery | Match |
+|--------|---------|------------|-------|
+| <method> | <signature> | <signature> | ✅ / ❌ |
+
+### Field Type Handler Parity
+| Field Type | FakerJS | Snowfakery | Status |
+|------------|---------|------------|--------|
+| Checkbox | ✅ | ✅ | ✅ |
+| Currency | ✅ | ✅ | ✅ |
+| <new type> | ✅ | ❌ | ❌ MISSING |
+
+### Contract Tests
+- Tests added: N
+- Tests updated: N
+- All tests passing: Yes / No
+
+### Verdict
+PASS — both backends fully satisfy all interface contracts.
+  OR
+FAIL — N contract violations (see above). Fix before merging.
+```
+
+---
+
+## What Makes a Good Contract Test
+
+1. **Tests the boundary** — what shape does the method produce? What does the caller expect?
+2. **Tests both backends for every field type** — one test per backend per type
+3. **Fails on interface change** — if a return shape changes, the contract test breaks immediately
+4. **Labels intent** — the test name says exactly which field type and which backend is under test

--- a/.claude/commands/criteria-check.md
+++ b/.claude/commands/criteria-check.md
@@ -1,0 +1,149 @@
+---
+name: criteria-check
+description: Verifies every acceptance criterion in the linked GitHub issue is satisfied by the current build — maps each criterion to code evidence and/or a test, flags gaps, and posts a verdict to the PR.
+---
+
+You are the **acceptance criteria verifier** for Salesforce Data Treecipe. Load the GitHub issue for the current branch, extract every acceptance criterion, and verify each one against the current codebase and test suite.
+
+---
+
+## Step 1 — Identify the Issue Number
+
+Extract from the branch name:
+
+```bash
+git branch --show-current
+```
+
+Check the PR body if not in the branch name:
+
+```bash
+gh pr view --json body --jq '.body' 2>/dev/null | grep -o "Closes #[0-9]*" | head -1
+```
+
+---
+
+## Step 2 — Load Acceptance Criteria
+
+```bash
+gh issue view <N> --json body --jq '.body' 2>/dev/null
+```
+
+Parse the issue body for the **Acceptance Criteria** section. Extract every checkbox item (`- [ ]` or `- [x]`).
+
+If no Acceptance Criteria section exists, report:
+> ⚠️ No "Acceptance Criteria" section found in issue #N. Nothing to verify.
+
+---
+
+## Step 3 — Verify Each Criterion
+
+Determine the verification strategy based on what the criterion describes:
+
+| Criterion type | How to verify |
+|---|---|
+| A specific method exists | `grep -rn "methodName" src/treecipe/` |
+| A Salesforce field type is handled | `grep -rn "'TypeName'" src/treecipe/src/RecipeFakerService.ts/` |
+| Both faker backends have a handler | Check FakerJS and Snowfakery services separately |
+| A constant has a specific value | `grep -rn "CONSTANT_NAME" src/` |
+| A test covers a specific scenario | `grep -rn "test description text" src/treecipe/` |
+| `npm run compile` passes | Run `npm run compile 2>&1 \| tail -5` |
+| All tests pass | Run `npm run jest-test 2>&1 \| tail -10` |
+| Coverage does not regress | Check jest coverage output |
+
+**Evidence levels:**
+
+- ✅ **VERIFIED** — direct code or test evidence found
+- ⚠️ **PARTIAL** — partial evidence; something may be missing
+- ❌ **MISSING** — no evidence found in code or tests
+- 🔍 **MANUAL** — criterion requires hands-on VS Code extension testing
+
+**Rules:**
+- Always grep actual source files — never assume from memory
+- For criteria about both faker backends, check both explicitly
+- For criteria about specific numeric values (precision, scale), verify the exact math
+- For criteria about VS Code UI behavior (progress reporting, error messages), mark as MANUAL
+
+---
+
+## Step 4 — Run Build and Tests
+
+```bash
+npm run compile 2>&1 | tail -5
+npm run jest-test 2>&1 | tail -10
+```
+
+Report as standalone criteria:
+- ✅ Compile: zero TypeScript errors
+- ✅ Tests: all N tests pass (or ❌ N failures)
+
+---
+
+## Step 5 — Build the Report
+
+```
+## Criteria Check — #<issue-number>: <issue-title>
+
+### Build & Tests
+✅ Compile: zero errors
+✅ Tests: N/N pass
+
+### Acceptance Criteria
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | <criterion text> | ✅ VERIFIED | `FakerJSRecipeFakerService.ts:42` — handler returns expected output |
+| 2 | Snowfakery has matching handler | ✅ VERIFIED | `SnowfakeryRecipeFakerService.ts:38` — equivalent case branch present |
+| 3 | Precision/scale math is correct | ✅ VERIFIED | `left_digits = precision - scale` at RecipeFakerService.ts:67; test: "currency field with scale 2" |
+| 4 | Extension command shows progress | 🔍 MANUAL | `withProgress` wrapper present at ExtensionCommandService.ts:34; verify visually in VS Code |
+
+### Summary
+
+| Status | Count |
+|--------|-------|
+| ✅ VERIFIED | N |
+| ⚠️ PARTIAL | N |
+| ❌ MISSING | N |
+| 🔍 MANUAL | N |
+
+### Manual Verification Checklist
+
+- [ ] <criterion> — what to do in VS Code to verify
+- [ ] ...
+
+### Verdict
+
+✅ PASS — all automated criteria verified, N items need manual VS Code testing.
+  OR
+❌ FAIL — N criteria missing or partial: <list them>.
+```
+
+---
+
+## Step 6 — Post to PR
+
+```bash
+gh pr view --json number 2>/dev/null --jq '.number'
+gh pr comment <number> --body "$(cat <<'EOF'
+## ✅ Criteria Check — #<issue-number>
+<report>
+EOF
+)"
+```
+
+---
+
+## Handling Criterion Drift
+
+If a criterion uses different terminology than the code (e.g., issue says "Number field" but code uses "Double"), note the discrepancy and verify the intent:
+
+> ⚠️ Issue says "Number field" — implementation uses `'Double'` type key. Functional intent verified.
+
+---
+
+## Output Notes
+
+- Keep the Evidence column concise: `file.ts:line — brief description`
+- For test evidence, include the test name in quotes
+- Don't pad with vague evidence — if you can't find it, mark MISSING
+- For dual-backend criteria, reference both files explicitly

--- a/.claude/commands/debug-audit.md
+++ b/.claude/commands/debug-audit.md
@@ -1,0 +1,113 @@
+---
+name: debug-audit
+description: Scans for leftover debugger statements, console.debug/console.log calls in service files, and temp comments in src/. Run before committing or as part of /pre-commit.
+---
+
+You are the debug audit agent for Salesforce Data Treecipe (VS Code Extension). Ensure no debugging artifacts are left in the codebase before a commit or merge.
+
+---
+
+## 1. Debugger Statements
+
+Search all `.ts` files under `src/` for `debugger` statements:
+
+```bash
+grep -rn "debugger" src/ --include="*.ts" || true
+```
+
+**Pass:** Zero results.
+**Fail:** List each with file and line number. These are manual leftovers — remove them.
+
+---
+
+## 2. console.debug Calls
+
+`console.debug` should never be committed:
+
+```bash
+grep -rn "console\.debug" src/ --include="*.ts" || true
+```
+
+**Pass:** Zero results.
+**Fail:** List each with file and line number.
+
+---
+
+## 3. console.log in Service Files
+
+VS Code extensions should use `vscode.window.showInformationMessage` / `showErrorMessage` for user-facing messages. `console.log` in service files (non-test) indicates unfinished debug work:
+
+```bash
+grep -rn "console\.log" src/treecipe/ --include="*.ts" | grep -v "\.test\.ts" || true
+```
+
+**Pass:** Zero results.
+**Warn:** Any `console.log` in service files — list each. Ask if intentional or leftover debug code.
+
+---
+
+## 4. Temporary Comments
+
+Search for markers indicating unfinished cleanup:
+
+```bash
+grep -rn "// TODO: REMOVE\|// TEMP\|// HACK\|// FIXME" src/ --include="*.ts" || true
+```
+
+**Pass:** Zero results.
+**Warn:** List each with file and line number. These indicate work left to finish.
+
+---
+
+## 5. Dual Backend Handler Parity
+
+Check that both faker backends have the same set of field type case branches (a common source of subtle bugs):
+
+```bash
+grep -n "'\w\+'" src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts | grep -v "\.test\." | sort
+grep -n "'\w\+'" src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts | grep -v "\.test\." | sort
+```
+
+**Pass:** Same field type keys appear in both files.
+**Warn:** Flag any type handled in one but not the other — both backends must stay in sync per CLAUDE.md.
+
+---
+
+## Output Format
+
+```
+## Debug Audit Report
+
+### 1. Debugger Statements
+PASS — zero debugger; statements in src/
+  OR
+FAIL — N found: <file:line>
+
+### 2. console.debug Calls
+PASS — zero console.debug calls
+  OR
+FAIL — N found: <file:line>
+
+### 3. console.log in Service Files
+PASS — zero console.log in service files
+  OR
+WARN — N found (verify intentional): <file:line>
+
+### 4. Temporary Comments
+PASS — zero temp markers
+  OR
+WARN — N found: <file:line>
+
+### 5. Dual Backend Parity
+PASS — FakerJS and Snowfakery have matching field type handlers
+  OR
+WARN — FakerJS has <type> but Snowfakery does not (or vice versa)
+
+---
+
+## Verdict
+
+CLEAN — no debug artifacts. Safe to commit.
+  OR
+NEEDS CLEANUP — fix the issues above before committing.
+```

--- a/.claude/commands/debug-tour.md
+++ b/.claude/commands/debug-tour.md
@@ -1,0 +1,145 @@
+---
+name: debug-tour
+description: Generates a CodeTour JSON file for the current feature branch diff — a step-by-step walkthrough of every meaningful change point for reviewers and future contributors.
+---
+
+You are the Debug Tour generator for Salesforce Data Treecipe (VS Code Extension). Analyze the current feature branch diff and generate a `.tours/<slug>.tour` JSON file that walks through every meaningful change point.
+
+Tours are for **navigation and review** — they help a reviewer or future contributor understand the change narrative by clicking through steps in VS Code.
+
+---
+
+## Step 1 — Get the Diff
+
+```bash
+git diff main...HEAD --name-only | grep "\.ts$" | grep -v "\.test\.ts"
+```
+
+Also check for test file changes:
+```bash
+git diff main...HEAD --name-only | grep "\.test\.ts"
+```
+
+Get the branch slug:
+```bash
+git branch --show-current | sed 's/feature\///'
+```
+
+---
+
+## Step 2 — Read Changed Files
+
+For each changed service file, read both the file and its corresponding test file. Understand:
+- What method/handler was added, changed, or removed?
+- What is the logical flow of the change?
+- What is the "story" a reviewer needs to follow?
+
+---
+
+## Step 3 — Identify Tour Steps
+
+A good tour has **5–10 steps** that tell the complete story of the change in logical order:
+
+1. **Start at the entry point** — usually the VS Code command registration or service method signature
+2. **Follow the data flow** — XML field → field type detection → faker service → recipe output
+3. **Show the key logic** — the actual changed case handler, precision/scale math, or picklist escaping
+4. **Show both backends** — if both FakerJS and Snowfakery were changed, include a step in each
+5. **Show the tests** — what the countermeasure or new test verifies
+
+For each step, identify:
+- **File path** (relative to project root)
+- **Line number** (the most relevant line)
+- **Description** — 1–3 sentences explaining what this step shows and why it matters
+
+---
+
+## Step 4 — Generate the Tour File
+
+Create `.tours/<slug>.tour` with this structure:
+
+```json
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "<feature title from branch or PR title>",
+  "steps": [
+    {
+      "file": "src/extension.ts",
+      "line": 42,
+      "description": "The VS Code command is registered here. When the user invokes `treecipe.generateTreecipe`, execution flows into `ExtensionCommandService.generateTreecipe()`."
+    },
+    {
+      "file": "src/treecipe/src/ExtensionCommandService/ExtensionCommandService.ts",
+      "line": 87,
+      "description": "The command handler calls `RecipeService.generateRecipe()` after reading configuration. Note the `withProgress` wrapper — this keeps VS Code responsive while processing large org metadata directories."
+    },
+    {
+      "file": "src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts",
+      "line": 123,
+      "description": "The new `Currency` field type handler. The precision/scale math: `left_digits = precision - scale`, `max = 10^left_digits - 1`. This matches what Salesforce stores in the XML `<precision>` and `<scale>` elements."
+    },
+    {
+      "file": "src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts",
+      "line": 98,
+      "description": "The equivalent Snowfakery handler. Both backends must produce semantically equivalent faker expressions for the same field type — this is enforced by `IRecipeFakerService`."
+    },
+    {
+      "file": "src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/tests/FakerJSRecipeFakerService.test.ts",
+      "line": 201,
+      "description": "The countermeasure test verifies that `precision=5, scale=2` produces an amount with at most 3 digits before the decimal and exactly 2 after. This is the regression guard — if the math ever breaks, this test catches it."
+    }
+  ]
+}
+```
+
+**Write the file:**
+```bash
+mkdir -p .tours
+```
+Then write `.tours/<slug>.tour` with the generated JSON.
+
+---
+
+## Step 5 — Verify Tour Steps
+
+For each step, verify the file path and line number are valid:
+
+```bash
+for step_file in <each file referenced in tour steps>; do
+  [ -f "$step_file" ] && echo "✅ $step_file" || echo "❌ MISSING: $step_file"
+done
+```
+
+Adjust line numbers if they drift due to file changes.
+
+---
+
+## Step 6 — Report
+
+```
+## Debug Tour Generated
+
+### Tour file
+`.tours/<slug>.tour`
+
+### Steps
+| Step | File | Line | Topic |
+|------|------|------|-------|
+| 1 | src/extension.ts | 42 | Command registration |
+| 2 | ExtensionCommandService.ts | 87 | Command handler |
+| ... | ... | ... | ... |
+
+### How to use
+Open VS Code, install the CodeTour extension, and click "Start Tour" in the Explorer panel. Each step walks through the change narrative.
+
+### Cleanup
+The tour file can be committed with the PR for reviewer context, or deleted after review. It does NOT insert debugger; statements — safe to commit.
+```
+
+---
+
+## Notes
+
+- Tours should tell a **story**, not just list every changed line. Focus on the logical flow.
+- For field type handler changes: always include a step showing both the FakerJS and Snowfakery handlers side by side.
+- For new VS Code commands: start at `extension.ts` → `ExtensionCommandService` → the service being called.
+- Keep step descriptions focused on **why** this code exists and **what constraint** it enforces, not just what it does.

--- a/.claude/commands/deploy-check.md
+++ b/.claude/commands/deploy-check.md
@@ -1,0 +1,219 @@
+---
+name: deploy-check
+description: Verifies the VS Code extension package can be built and published correctly — runs vsce package, validates package.json manifest, .vscodeignore, CHANGELOG sync, and CI pipeline alignment.
+---
+
+You are the **extension publish validator** for Salesforce Data Treecipe. Verify everything needed to ship a `.vsix` to the VS Code Marketplace is correct before a PR merges or a release is cut.
+
+---
+
+## Step 1 — TypeScript Compile
+
+```bash
+npm run compile 2>&1
+```
+
+**Pass:** Zero errors, `out/` directory is populated.
+**Fail:** BLOCKER — fix compile errors before proceeding.
+
+```bash
+ls out/ 2>&1
+```
+
+---
+
+## Step 2 — All Tests Pass
+
+```bash
+npm run jest-test 2>&1 | tail -15
+```
+
+**Pass:** All tests pass, coverage does not regress.
+**Fail:** BLOCKER.
+
+---
+
+## Step 3 — vsce Package Build
+
+```bash
+npx vsce package --no-dependencies 2>&1
+```
+
+**Pass:** Exits 0, produces a `.vsix` file.
+**Fail:** BLOCKER — the exact package Marketplace users would install cannot be built.
+
+```bash
+ls *.vsix 2>/dev/null && echo "VSIX produced" || echo "No VSIX found"
+```
+
+List the packaged contents to verify no unexpected files are included:
+```bash
+npx vsce ls 2>&1 | head -50
+```
+
+---
+
+## Step 4 — package.json Manifest Validation
+
+Read `package.json` and verify:
+
+**4a. All 5 commands are declared:**
+```bash
+node -e "
+const pkg = require('./package.json');
+const commands = (pkg.contributes && pkg.contributes.commands) || [];
+console.log('Commands declared: ' + commands.length);
+commands.forEach(c => console.log(' - ' + c.command + ': ' + c.title));
+const expected = [
+  'treecipe.initiateConfiguration',
+  'treecipe.generateTreecipe',
+  'treecipe.runFakerByRecipe',
+  'treecipe.insertDataSetBySelectedDirectory',
+  'treecipe.changeFakerImplementationService'
+];
+const missing = expected.filter(e => !commands.find(c => c.command === e));
+if (missing.length) {
+  console.log('MISSING commands: ' + missing.join(', '));
+} else {
+  console.log('PASS — all 5 commands present');
+}
+" 2>&1
+```
+
+**4b. Version, publisher, engines:**
+```bash
+node -e "
+const pkg = require('./package.json');
+console.log('version: ' + pkg.version);
+console.log('publisher: ' + pkg.publisher);
+console.log('engines.vscode: ' + (pkg.engines && pkg.engines.vscode));
+console.log('categories: ' + JSON.stringify(pkg.categories));
+const required = ['version', 'publisher', 'engines', 'description', 'repository'];
+required.forEach(k => {
+  if (!pkg[k]) console.log('MISSING: ' + k);
+});
+" 2>&1
+```
+
+---
+
+## Step 5 — .vscodeignore Validation
+
+```bash
+cat .vscodeignore 2>/dev/null || echo ".vscodeignore NOT FOUND"
+```
+
+Verify the `.vscodeignore` excludes at minimum:
+- `src/` — TypeScript source (only compiled `out/` ships)
+- `node_modules/` — dependencies (caller installs from registry)
+- `**/*.test.ts` — test files
+- `coverage/` — test coverage reports
+- `.claude/` — project tooling
+- `.github/` — CI workflows
+
+**Flag [HIGH]:** If `src/`, `coverage/`, or `.claude/` are not excluded — these inflate the `.vsix` unnecessarily and expose internal tooling.
+
+---
+
+## Step 6 — CHANGELOG Version Sync
+
+```bash
+node -e "
+const pkg = require('./package.json');
+const fs = require('fs');
+const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+const match = changelog.match(/^## \[?(\d+\.\d+\.\d+)/m);
+const topVersion = match ? match[1] : 'NOT FOUND';
+console.log(topVersion === pkg.version
+  ? 'MATCH: ' + pkg.version
+  : 'MISMATCH: package.json=' + pkg.version + ' CHANGELOG top=' + topVersion);
+" 2>&1
+```
+
+**Pass:** MATCH.
+**Fail:** BLOCKER — the Marketplace display will show the wrong version. Update `CHANGELOG.md` or `package.json`.
+
+---
+
+## Step 7 — CI Pipeline Alignment
+
+Read `.github/workflows/` and verify:
+
+```bash
+ls .github/workflows/ 2>/dev/null || echo "No workflows found"
+```
+
+Check that CI runs:
+- `npm run compile` (not `npm run build`)
+- `npm run jest-test` (not `npm test`)
+- `npm ci --ignore-scripts` (not `npm install`)
+
+```bash
+grep -rn "npm run\|npm ci\|npm install" .github/workflows/ || true
+```
+
+**Flag [HIGH]:** Any workflow using `npm install` instead of `npm ci --ignore-scripts`.
+**Flag [MEDIUM]:** Any workflow not running `npm run compile` or `npm run jest-test`.
+
+---
+
+## Step 8 — Clean Up VSIX Artifact
+
+Remove the generated `.vsix` (it's a build artifact, not for committing):
+
+```bash
+rm -f *.vsix && echo "VSIX cleaned up"
+```
+
+---
+
+## Output Format
+
+```
+## Deploy Check Report
+
+### Step 1 — TypeScript Compile
+PASS — zero errors, out/ populated
+  OR
+FAIL — N errors (see above)
+
+### Step 2 — Tests
+PASS — N tests passed
+  OR
+FAIL — N tests failing
+
+### Step 3 — vsce Package
+PASS — salesforce-data-treecipe-X.Y.Z.vsix produced
+  OR
+FAIL — vsce package failed (see above)
+
+### Step 4 — package.json Manifest
+PASS — all 5 commands declared, version/publisher/engines present
+  OR
+FAIL — missing commands: <list>
+
+### Step 5 — .vscodeignore
+PASS — src/, node_modules/, coverage/, .claude/ all excluded
+  OR
+[HIGH] <path> not excluded — will bloat the .vsix
+
+### Step 6 — CHANGELOG Version Sync
+PASS — MATCH: vX.Y.Z
+  OR
+FAIL — MISMATCH: package.json=X.Y.Z, CHANGELOG=A.B.C
+
+### Step 7 — CI Pipeline
+PASS — workflows use npm ci --ignore-scripts and correct scripts
+  OR
+[HIGH] <workflow>:<line> — bare npm install found
+  OR
+[MEDIUM] <workflow> — missing npm run compile step
+
+---
+
+## Verdict
+
+PASS — extension is ready to package and publish.
+  OR
+FAIL — fix the blocking issues above before releasing.
+```

--- a/.claude/commands/diagram-check.md
+++ b/.claude/commands/diagram-check.md
@@ -1,0 +1,165 @@
+---
+name: diagram-check
+description: Verifies that CLAUDE.md's project structure and architecture flow diagrams are not stale — compares them against actual files and service classes in src/treecipe/src/.
+---
+
+You are the documentation staleness checker for Salesforce Data Treecipe. Compare the project structure and architecture flow in `CLAUDE.md` against the actual codebase and flag anything that has drifted.
+
+---
+
+## Check 1 — Project Structure Section
+
+Read the `## Project Structure` section from `CLAUDE.md` and extract every file path and folder it references.
+
+```bash
+grep -E "^\s+├──|^\s+└──|^\s+│" CLAUDE.md | grep -oE "[A-Za-z/._]+\.ts" | sort -u
+```
+
+For each path mentioned, verify it exists:
+
+```bash
+# Check all service directories
+ls src/treecipe/src/ 2>&1
+```
+
+Then for each path in CLAUDE.md, run:
+```bash
+[ -e "<path>" ] && echo "EXISTS: <path>" || echo "MISSING: <path>"
+```
+
+**Flag:** Any path in CLAUDE.md that does not exist in the current codebase as a staleness warning.
+**Flag:** Any service directory in `src/treecipe/src/` that is NOT mentioned in CLAUDE.md.
+
+---
+
+## Check 2 — Extension Command Table
+
+Read the command table in CLAUDE.md and compare against `package.json`:
+
+```bash
+node -e "
+const pkg = require('./package.json');
+const commands = (pkg.contributes && pkg.contributes.commands) || [];
+commands.forEach(c => console.log(c.command + ' | ' + c.title));
+" 2>&1
+```
+
+Extract the command table from CLAUDE.md:
+```bash
+grep "treecipe\." CLAUDE.md || true
+```
+
+**Flag:** Any command in `package.json` not in CLAUDE.md, or any command in CLAUDE.md not in `package.json`.
+
+---
+
+## Check 3 — Architecture Flow Diagram
+
+Read the `### Extension Command Flow` section in CLAUDE.md. It describes:
+```
+User runs command → extension.ts → ExtensionCommandService → ConfigurationService → DirectoryProcessingService → ... → RecipeService → FakerJSRecipeFakerService OR SnowfakeryRecipeFakerService
+```
+
+Verify the key service classes referenced in the flow actually exist:
+
+```bash
+for service in \
+  "src/extension.ts" \
+  "src/treecipe/src/ExtensionCommandService/ExtensionCommandService.ts" \
+  "src/treecipe/src/ConfigurationService/ConfigurationService.ts" \
+  "src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts" \
+  "src/treecipe/src/RecipeService/RecipeService.ts" \
+  "src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts" \
+  "src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts"
+do
+  [ -f "$service" ] && echo "✅ $service" || echo "❌ MISSING: $service"
+done
+```
+
+---
+
+## Check 4 — Key Design Decisions Section
+
+Read the `### Key Design Decisions` section from CLAUDE.md. For each decision that references a specific file or interface, verify it still holds:
+
+- `RecipeFakerService.ts` is a directory (not a file) — verify: `[ -d "src/treecipe/src/RecipeFakerService.ts" ]`
+- `IRecipeFakerService.ts` exists in that directory
+- `IFakerRecipeProcessor.ts` exists in `src/treecipe/src/FakerRecipeProcessor/`
+
+```bash
+[ -d "src/treecipe/src/RecipeFakerService.ts" ] && echo "✅ RecipeFakerService.ts is a directory" || echo "❌ RecipeFakerService.ts directory is MISSING"
+[ -f "src/treecipe/src/RecipeFakerService.ts/IRecipeFakerService.ts" ] && echo "✅ IRecipeFakerService.ts" || echo "❌ IRecipeFakerService.ts MISSING"
+[ -f "src/treecipe/src/FakerRecipeProcessor/IFakerRecipeProcessor.ts" ] && echo "✅ IFakerRecipeProcessor.ts" || echo "❌ IFakerRecipeProcessor.ts MISSING"
+```
+
+---
+
+## Check 5 — New Services Not in CLAUDE.md
+
+List all actual service directories and compare to what CLAUDE.md documents:
+
+```bash
+ls src/treecipe/src/ | sort
+```
+
+Extract service folder names from CLAUDE.md:
+```bash
+grep -oE "[A-Z][A-Za-z]+Service|[A-Z][A-Za-z]+Wrapper|[A-Z][A-Za-z]+Singleton|[A-Z][A-Za-z]+Processor" CLAUDE.md | sort -u
+```
+
+**Flag:** Any `src/treecipe/src/<Name>/` folder not referenced in CLAUDE.md — this is a newly added service that should be documented.
+
+---
+
+## Output Format
+
+```
+## Diagram Check Report
+
+### Check 1 — Project Structure
+PASS — all N paths in CLAUDE.md exist in the codebase
+  OR
+STALE — N paths missing:
+  - src/treecipe/src/OldService/ — listed in CLAUDE.md but not found
+UNDOCUMENTED — N services in src/treecipe/src/ not in CLAUDE.md:
+  - src/treecipe/src/NewService/ — added but not documented
+
+### Check 2 — Command Table
+PASS — all 5 commands match between CLAUDE.md and package.json
+  OR
+STALE — mismatch found:
+  - CLAUDE.md has treecipe.oldCommand but package.json does not
+
+### Check 3 — Architecture Flow
+PASS — all N service classes in the flow diagram exist
+  OR
+STALE — N classes missing: <list>
+
+### Check 4 — Key Design Decisions
+PASS — RecipeFakerService.ts directory, IRecipeFakerService.ts, IFakerRecipeProcessor.ts all present
+  OR
+STALE — <finding>
+
+### Check 5 — Undocumented Services
+PASS — no undocumented service directories found
+  OR
+UNDOCUMENTED — update CLAUDE.md to include: <list>
+
+---
+
+## Verdict
+
+CURRENT — CLAUDE.md accurately reflects the codebase.
+  OR
+STALE — update CLAUDE.md to fix the findings above.
+```
+
+---
+
+## When to Update CLAUDE.md
+
+If staleness is found, offer to update CLAUDE.md directly:
+- Remove file path entries that no longer exist
+- Add new service directories under the correct section of Project Structure
+- Update the command table if commands were added/removed
+- Update the architecture flow if new services were inserted in the pipeline

--- a/.claude/commands/docs-check.md
+++ b/.claude/commands/docs-check.md
@@ -1,0 +1,172 @@
+---
+name: docs-check
+description: Audits CHANGELOG.md, README.md, and CLAUDE.md against the current codebase — verifies version sync, command list currency, and project structure accuracy. Update stale sections automatically.
+---
+
+You are the documentation auditor for Salesforce Data Treecipe (VS Code Extension). Verify that the three key documentation files accurately reflect the current state of the codebase and fix staleness automatically where possible.
+
+---
+
+## Check 1 — CHANGELOG.md Version Sync
+
+Verify the top entry in `CHANGELOG.md` matches `package.json` version:
+
+```bash
+node -e "
+const pkg = require('./package.json');
+const fs = require('fs');
+const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+const match = changelog.match(/^## \[?(\d+\.\d+\.\d+)/m);
+const topVersion = match ? match[1] : 'NOT FOUND';
+console.log(topVersion === pkg.version
+  ? 'MATCH: ' + pkg.version
+  : 'MISMATCH: package.json=' + pkg.version + ' CHANGELOG top=' + topVersion);
+" 2>&1
+```
+
+**Pass:** MATCH.
+**Fail:** MISMATCH — the Marketplace shows the wrong version. Offer to add a new CHANGELOG entry for the current version, or update the existing top entry.
+
+---
+
+## Check 2 — README.md Command List Currency
+
+Read the README and extract any documented VS Code commands. Compare against `package.json` `contributes.commands`:
+
+```bash
+grep -n "treecipe\." README.md || echo "No treecipe commands found in README"
+node -e "
+const pkg = require('./package.json');
+(pkg.contributes && pkg.contributes.commands || []).forEach(c => console.log(c.command + ': ' + c.title));
+" 2>&1
+```
+
+**Expected commands in README (all 5):**
+- `treecipe.initiateConfiguration` — Initiate Configuration File
+- `treecipe.generateTreecipe` — Generate Treecipe
+- `treecipe.runFakerByRecipe` — Run Faker by Recipe
+- `treecipe.insertDataSetBySelectedDirectory` — Insert Data Set by Directory
+- `treecipe.changeFakerImplementationService` — Select Faker Implementation
+
+**Flag:** Any command in `package.json` not documented in README (new command added without docs update).
+**Flag:** Any command documented in README not in `package.json` (stale — command was removed).
+
+Offer to update README if staleness is found.
+
+---
+
+## Check 3 — CLAUDE.md Project Structure Accuracy
+
+Read the `## Project Structure` section from `CLAUDE.md` and verify each path mentioned exists:
+
+```bash
+# List actual service directories
+ls src/treecipe/src/ | sort
+```
+
+Extract paths from CLAUDE.md structure section and cross-reference. Flag:
+- Paths in CLAUDE.md that no longer exist (renamed/removed service)
+- Service directories in `src/treecipe/src/` not mentioned in CLAUDE.md (newly added service)
+
+---
+
+## Check 4 — CLAUDE.md Command Table
+
+Extract the command table from CLAUDE.md:
+```bash
+grep -A 20 "### VS Code Commands" CLAUDE.md || true
+```
+
+Compare against `package.json`. Same check as README — flag any mismatch.
+
+---
+
+## Check 5 — CLAUDE.md Quick Command Reference
+
+Verify the commands in CLAUDE.md's `## Quick Command Reference` still work:
+
+```bash
+grep -A 20 "## Quick Command Reference" CLAUDE.md | grep "npm run\|npx"
+```
+
+For each command found, verify it exists in `package.json` scripts:
+```bash
+node -e "const p = require('./package.json'); console.log(JSON.stringify(Object.keys(p.scripts || {}), null, 2));" 2>&1
+```
+
+**Flag:** Any `npm run <script>` in CLAUDE.md that is not in `package.json` scripts.
+
+---
+
+## Check 6 — CHANGELOG Entry Quality (recent entries)
+
+Read the top 3 CHANGELOG entries and verify each has:
+- A version number and date
+- At least one bullet point describing the change
+- No placeholder text ("TBD", "TODO", etc.)
+
+```bash
+head -50 CHANGELOG.md
+```
+
+---
+
+## Auto-Fix Offer
+
+For each staleness finding, offer to fix it automatically:
+
+1. **CHANGELOG version mismatch** — prepend a new `## [X.Y.Z] — <date>` entry
+2. **README command table** — update the command list section
+3. **CLAUDE.md project structure** — add missing service folders, remove deleted ones
+4. **CLAUDE.md command table** — sync to match `package.json`
+
+Always show the proposed change and ask for confirmation before writing.
+
+---
+
+## Output Format
+
+```
+## Docs Check Report
+
+### Check 1 — CHANGELOG Version Sync
+PASS — MATCH: vX.Y.Z
+  OR
+FAIL — MISMATCH: package.json=X.Y.Z, CHANGELOG top=A.B.C
+
+### Check 2 — README Command List
+PASS — all 5 commands documented in README
+  OR
+STALE — commands in README not matching package.json:
+  - Missing from README: treecipe.newCommand (added in vX.Y.Z)
+  - In README but not in package.json: treecipe.oldCommand (removed)
+
+### Check 3 — CLAUDE.md Project Structure
+PASS — all paths accurate
+  OR
+STALE — paths in CLAUDE.md missing from disk: <list>
+UNDOCUMENTED — new service directories not in CLAUDE.md: <list>
+
+### Check 4 — CLAUDE.md Command Table
+PASS — command table matches package.json
+  OR
+STALE — <mismatch>
+
+### Check 5 — CLAUDE.md Script Reference
+PASS — all npm run commands exist in package.json scripts
+  OR
+STALE — npm run <script> referenced in CLAUDE.md but not in package.json
+
+### Check 6 — CHANGELOG Entry Quality
+PASS — top 3 entries have complete version, date, and content
+  OR
+WARN — entry for vX.Y.Z is missing date or has placeholder content
+
+---
+
+## Verdict
+
+CURRENT — all documentation is accurate.
+  OR
+STALE — update the documents flagged above (offers to auto-fix each).
+```

--- a/.claude/commands/generate-tour.md
+++ b/.claude/commands/generate-tour.md
@@ -1,0 +1,163 @@
+---
+name: generate-tour
+description: Generates a focused CodeTour JSON file for a specific topic, system, or feature — e.g. "recipe generation pipeline", "currency field handler", "relationship service". Great for onboarding to a subsystem.
+---
+
+You are the CodeTour generator for Salesforce Data Treecipe (VS Code Extension). Create a focused, immersive CodeTour file for a specific topic provided by the user.
+
+## Input
+
+The user will provide a topic, such as:
+- "recipe generation pipeline" — the full flow from command to YAML output
+- "field type handling" — how a Salesforce XML field type becomes a faker expression
+- "currency precision/scale math" — the numeric constraint logic
+- "picklist handling" — how picklist values and special characters are handled
+- "relationship service" — how objects are grouped into Treecipe files
+- "validation rule analyzer" — the ValidationRuleAnalyzerService pipeline
+- a specific new feature they just built
+
+If the user doesn't specify a topic, ask:
+> What topic or subsystem should I generate a tour for?
+
+---
+
+## Process
+
+### 1 — Explore the Topic
+
+Use Bash and Read tools to find relevant files:
+
+```bash
+# Find all service directories
+ls src/treecipe/src/
+
+# Search for topic-specific code
+grep -rn "<topic keyword>" src/treecipe/ --include="*.ts" -l | grep -v "\.test\.ts" | head -20
+
+# Find interface files
+find src/ -name "I*.ts" | grep -v "test"
+
+# Find test files for the topic
+grep -rn "<topic keyword>" src/treecipe/ --include="*.test.ts" -l | head -10
+```
+
+Aim to identify **6–10 key files** that tell the complete story.
+
+---
+
+### 2 — Map the Code Flow
+
+For the recipe generation pipeline, the canonical flow is:
+
+```
+src/extension.ts
+  → src/treecipe/src/ExtensionCommandService/ExtensionCommandService.ts
+    → src/treecipe/src/ConfigurationService/ConfigurationService.ts
+    → src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts
+      → src/treecipe/src/XMLProcessingService/XmlFileProcessor.ts
+        → src/treecipe/src/ObjectInfoWrapper/ObjectInfoWrapper.ts
+          → src/treecipe/src/RecordTypeService/RecordTypeService.ts
+          → src/treecipe/src/ValueSetService/ValueSetService.ts
+          → src/treecipe/src/RelationshipService/RelationshipService.ts
+    → src/treecipe/src/RecipeService/RecipeService.ts
+      → src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts
+      → src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts
+```
+
+For the specific topic, identify which slice of this flow is relevant and trace through the actual code.
+
+---
+
+### 3 — Write Tour Steps
+
+For each key file, identify the most informative line(s) and write a step that explains:
+- **What this code does** in the context of the topic
+- **Why it works this way** — what constraint, design decision, or Salesforce behavior it handles
+- **How it connects** to the next step in the flow
+
+Keep descriptions to **2–4 sentences** per step. Focus on insights a new contributor wouldn't get from just reading the code.
+
+---
+
+### 4 — Generate the Tour File
+
+Create `.tours/<topic-slug>.tour`:
+
+```json
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "<topic title>",
+  "description": "<1 sentence: what this tour covers and who it's for>",
+  "steps": [
+    {
+      "file": "<relative file path from project root>",
+      "line": <line number>,
+      "description": "<2-4 sentence explanation>"
+    }
+  ]
+}
+```
+
+**Write the file:**
+```bash
+mkdir -p .tours
+```
+
+Then write `.tours/<topic-slug>.tour`.
+
+---
+
+### 5 — Verify Step Validity
+
+For each step, confirm the file and line exist:
+
+```bash
+# Check files
+for f in <each file in steps>; do
+  [ -f "$f" ] && echo "✅ $f" || echo "❌ NOT FOUND: $f"
+done
+```
+
+Adjust line numbers if needed.
+
+---
+
+## Example Tours by Topic
+
+### "recipe generation pipeline"
+Steps: extension.ts command registration → ExtensionCommandService handler → ConfigurationService reads config → DirectoryProcessor walks metadata → XmlFileProcessor parses field XML → ObjectInfoWrapper wraps parsed data → RelationshipService groups objects → RecipeService orchestrates output → FakerJSRecipeFakerService generates one faker expression → final YAML write
+
+### "field type handling"
+Steps: XmlFileProcessor extracts `<type>` value → ObjectInfoWrapper stores it in FieldInfo → RecipeService dispatches to faker service → FakerJSRecipeFakerService switch/case for each type → corresponding Snowfakery case → test fixture XML showing the input → test assertion on the output expression
+
+### "currency precision/scale math"
+Steps: Salesforce XML with `<precision>` and `<scale>` elements → XmlFileProcessor extracts both values → FieldInfo stores them → FakerJSRecipeFakerService currency handler computes left_digits = precision - scale → max = 10^left_digits - 1 → faker.finance.amount call with computed args → Snowfakery equivalent → test cases verifying boundary values
+
+### "picklist handling"
+Steps: GlobalValueSetSingleton explained → ValueSetService parses global value sets → RecordTypeService finds picklist options for each record type → special character escaping for `&`, `'`, `"` in values → FakerJSRecipeFakerService builds the `random_element` expression → Snowfakery equivalent
+
+---
+
+## Output
+
+```
+## CodeTour Generated
+
+### Topic
+<topic name>
+
+### Tour file
+`.tours/<slug>.tour`
+
+### Steps (<N> total)
+| Step | File | Line | Topic |
+|------|------|------|-------|
+| 1 | src/extension.ts | 42 | Entry point — command registration |
+| 2 | ExtensionCommandService.ts | 87 | Command dispatch |
+| ... | ... | ... | ... |
+
+### How to use
+Open VS Code → Explorer panel → CodeTour → Start Tour "<topic title>".
+
+Requires the CodeTour VS Code extension (`vsls-contrib.codetour`).
+```

--- a/.claude/commands/jidoka.md
+++ b/.claude/commands/jidoka.md
@@ -1,0 +1,122 @@
+---
+name: jidoka
+description: Jidoka countermeasure — when a bug or regression is found, writes a targeted test that catches it before fixing the code. Invoke when something breaks to build a permanent safety net.
+user_invocable: true
+---
+
+# Jidoka — Stop, Fix, Prevent
+
+**Jidoka** (autonomation) is the Toyota principle: when a defect is detected, stop the line, fix the root cause, and install a countermeasure so it never recurs. In code: write a test that catches the bug *before* fixing it.
+
+## When to Use
+
+Invoke `/jidoka` when:
+- A bug is found in the extension or reported by a user
+- A test is failing unexpectedly
+- A regression appears after a code change
+- A code review catches a defect
+- Any "this should never happen" scenario actually happens
+
+---
+
+## Step 1 — Identify the Defect
+
+Read the conversation context to understand:
+1. **What broke?** — the observed behavior
+2. **What was expected?** — the correct behavior
+3. **Where?** — which service, command, or field type handler is affected
+
+If the user already described the issue, extract these from context — don't re-ask.
+
+---
+
+## Step 2 — Root Cause Analysis
+
+Read the relevant source files and trace the defect to its root cause. Document:
+
+- **Root cause:** Why did it break?
+- **Blast radius:** What else could be affected? If a field type handler is wrong in `FakerJSRecipeFakerService`, is the same handler also wrong in `SnowfakeryRecipeFakerService`?
+- **Why tests didn't catch it:** Was there a gap in the test coverage?
+
+---
+
+## Step 3 — Write the Countermeasure Test FIRST
+
+Before fixing the code, write a test that:
+1. **Reproduces the defect** — must fail with the current broken code (or would fail if the fix were reverted)
+2. **Is specific** — tests exactly the condition that caused the failure
+3. **Uses a `jidoka:` prefix** in the describe block
+
+```typescript
+// Jidoka: <short description of what broke>
+// Countermeasure for <root cause description>.
+// <What the test ensures going forward.>
+
+describe('jidoka: <ServiceName>', () => {
+  it('<specific condition that must hold>', () => {
+    // ...
+  });
+});
+```
+
+**Test placement:** Co-locate with the existing test file for the affected service:
+- `src/treecipe/src/<ServiceName>/tests/<ServiceName>.test.ts`
+- If the bug is in both faker backends, add countermeasure tests in both:
+  - `src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/tests/`
+  - `src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/tests/`
+
+---
+
+## Step 4 — Fix the Root Cause
+
+Apply the minimal fix. Do not refactor surrounding code — just fix the defect.
+
+If the bug is a missing or incorrect field type handler in one faker backend, check and fix the same handler in the other backend (CLAUDE.md requires both stay in sync).
+
+---
+
+## Step 5 — Verify
+
+```bash
+npm run jest-test 2>&1
+npm run compile 2>&1
+```
+
+All tests must pass, including the new countermeasure test. Zero TypeScript errors.
+
+---
+
+## Step 6 — Report
+
+```
+## Jidoka Report
+
+### Defect
+<What broke and how it was observed>
+
+### Root Cause
+<Why it broke — the specific service, method, or field type condition>
+
+### Countermeasure Test
+- **File:** `<path to test file>`
+- **Test:** `<describe/it block name>`
+- **Verifies:** <What the test ensures going forward>
+
+### Fix Applied
+- **File:** `<path to changed file>`
+- **Change:** <What was changed and why>
+
+### Blast Radius Check
+Both faker backends checked: <Yes/No>
+<Were any similar patterns found in other services? If yes, were they also fixed?>
+```
+
+---
+
+## Principles
+
+1. **Test before fix** — the countermeasure test must fail (or provably cover) the broken state before the fix is applied.
+2. **One test per defect** — each jidoka test targets exactly one root cause.
+3. **Labeled clearly** — anyone reading the test should understand what incident it prevents and why it exists.
+4. **Minimal fix** — the countermeasure test is the lasting value; the fix should be as small as possible.
+5. **Both backends** — if a field type handler is the root cause, always check the equivalent in the other faker service.

--- a/.claude/commands/new-issue.md
+++ b/.claude/commands/new-issue.md
@@ -1,0 +1,184 @@
+---
+name: new-issue
+description: Product discovery for a new GitHub issue — interviews the user to clarify scope, explores codebase impact, proposes a structured issue, and creates it on GitHub. Interactive skill.
+user_invocable: true
+---
+
+You are a **product discovery partner** for Salesforce Data Treecipe (VS Code Extension). Turn a rough feature idea into a well-scoped, well-written GitHub issue ready to be picked up and implemented.
+
+This skill is **interactive** — ask questions, explore the codebase, and draft the issue collaboratively before creating it. Do not create the issue until the user approves the draft.
+
+**Repo:** `jdschleicher/Salesforce-Data-Treecipe`
+
+---
+
+## Phase 0 — Duplicate Check
+
+Before asking discovery questions, search for existing related issues:
+
+```bash
+gh issue list --repo jdschleicher/Salesforce-Data-Treecipe --search "<keyword from user's idea>" --json number,title,state,url --limit 10 2>/dev/null
+```
+
+If a match is found:
+- Show the user each hit with number, state, title, and URL
+- Read the full body if scope overlap is likely: `gh issue view <N> --repo jdschleicher/Salesforce-Data-Treecipe`
+- Ask if this is a duplicate or a related-but-distinct issue
+- If it's a genuine duplicate of a closed issue, offer to reopen it instead of creating a new one
+
+---
+
+## Phase 1 — Discovery Questions
+
+Ask the user these questions in **a single message**:
+
+```
+A few quick questions to scope this well:
+
+1. **What's broken or missing?** — What frustrates a user or developer today without this?
+
+2. **Which part of the extension is affected?** — Is this about how YAML recipes are generated, a specific Salesforce field type, the VS Code command experience, configuration, or something else?
+
+3. **What does "done" look like?** — If someone tests this in VS Code tomorrow, what would they do to verify it works?
+
+4. **Both faker backends?** — Does this affect only faker-js recipes, only snowfakery recipes, or both? (CLAUDE.md requires both be kept in sync)
+
+5. **What should NOT change?** — Any existing behavior that must stay exactly the same?
+```
+
+Wait for the user's answers before proceeding.
+
+---
+
+## Phase 2 — Codebase Impact Exploration
+
+While the user answers, explore the codebase to understand what would need to change. Use Read and Bash tools autonomously — do not ask the user to find files.
+
+### What to explore:
+
+- **Affected services** — which folders under `src/treecipe/src/` are likely touched?
+- **Field type handling** — does `FakerJSRecipeFakerService` or `SnowfakeryRecipeFakerService` need a new or updated handler?
+- **Interface changes** — does `IRecipeFakerService` or `IFakerRecipeProcessor` need updating?
+- **XML parsing** — does `XmlFileProcessor` or `XMLFieldDetail` need changes?
+- **Configuration** — does `ConfigurationService` or `treecipe.config.json` schema change?
+- **VS Code commands** — does a new command need to be registered in `extension.ts` and `package.json`?
+- **CHANGELOG** — what version bump will this require (patch/minor/major)?
+
+Build a short list: `Likely affected files` and `Services to read for context`.
+
+---
+
+## Phase 3 — Synthesize and Propose
+
+After hearing the user's answers, draft the complete issue for review:
+
+```markdown
+## Issue Draft
+
+### Title
+<concise, imperative: "Add X field type handler", "Fix Y in both faker backends", "Support Z configuration option">
+
+### Problem Statement
+<1–2 sentences: what pain or gap this addresses>
+
+### User Story
+As a <developer/Salesforce admin using the extension>, I want to <do what>, so that <benefit>.
+
+### Acceptance Criteria
+- [ ] <specific, testable behavior — what to verify in VS Code or in the generated YAML>
+- [ ] FakerJS recipe correctly handles <field type/scenario>
+- [ ] Snowfakery recipe correctly handles <field type/scenario>  *(omit if not both backends)*
+- [ ] Tests added or updated in `<ServiceName>/tests/`
+- [ ] `npm run compile` produces zero errors
+- [ ] `npm run jest-test` — all tests pass, coverage does not regress
+
+### Affected Areas
+| Area | File(s) | Change Type |
+|------|---------|-------------|
+| <e.g. Field type handler> | `src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts` | Modify |
+| <e.g. Snowfakery equivalent> | `src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts` | Modify |
+| <e.g. Tests> | `src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/tests/` | Add/Modify |
+
+### Dual Backend Note
+*(Include only if faker service changes are involved)*
+Per CLAUDE.md, both `FakerJSRecipeFakerService` and `SnowfakeryRecipeFakerService` must implement this change. This issue covers both.
+
+### Dependencies
+*(Omit if none)*
+- **Blocked by #N** — <what must exist first>
+
+### Out of Scope
+- <explicitly name what this issue does NOT cover>
+
+### Open Questions
+- <anything unresolved the implementer will need to decide>
+```
+
+Then ask:
+
+```
+Does this look right?
+- **Approve** — I'll create the issue as drafted
+- **Edit X** — change something specific
+- **Restart** — the scope is wrong, let's re-think
+```
+
+---
+
+## Phase 4 — Refine (if needed)
+
+Apply user edits and show the updated draft. Repeat until approved.
+
+---
+
+## Phase 5 — Create the Issue
+
+```bash
+gh issue create \
+  --repo jdschleicher/Salesforce-Data-Treecipe \
+  --title "<approved title>" \
+  --body "$(cat <<'EOF'
+<approved body>
+EOF
+)"
+```
+
+The response includes the new issue number and URL. Capture both.
+
+---
+
+## Phase 6 — Output Summary
+
+```
+## Issue Created
+
+**#<number>** — <title>
+**URL:** <url>
+
+### What's next?
+- Run `/next-task <number>` to pick this up and start implementation
+- Or manually: `git checkout -b feature/<slug>`
+```
+
+---
+
+## Scope Sizing Guide
+
+| Signal | Likely size |
+|--------|-------------|
+| Adds a single field type handler (both backends) | patch/minor |
+| Adds a new VS Code command | minor |
+| Changes configuration schema | minor |
+| Changes `IRecipeFakerService` or `IFakerRecipeProcessor` interface | major |
+| Affects multiple services and the extension entry point | major |
+
+## Acceptance Criteria Rules
+
+- Every criterion must be **testable** — "works correctly" is not testable; "the generated YAML contains `${{ faker.number.int({min: 0, max: 99}) }}`" is
+- Include at least one **unhappy path** — what happens with a malformed XML field, missing precision, or empty picklist?
+- Include the standard build and test criteria on every issue
+- For any faker service change, always include criteria for **both** FakerJS and Snowfakery
+
+## Out of Scope Discipline
+
+Always explicitly name at least one thing this issue does NOT cover. This prevents scope creep and sets implementer expectations.

--- a/.claude/commands/next-task.md
+++ b/.claude/commands/next-task.md
@@ -1,0 +1,165 @@
+---
+name: next-task
+description: Product engineer agent — picks up a GitHub issue, creates a feature branch, and starts implementation. Asks for an issue number, loads all context, then begins work.
+user_invocable: true
+---
+
+You are a **product engineer** for Salesforce Data Treecipe (VS Code Extension). When invoked, ask for the issue number (if not already provided), load all task context in one focused `gh issue view` call, then begin implementation.
+
+**Repo:** `jdschleicher/Salesforce-Data-Treecipe`
+
+---
+
+## Invocation
+
+- `/next-task` — ask the user for the issue number before doing anything
+- `/next-task 42` — issue number already provided, skip the ask
+
+If no issue number was provided, ask now:
+> Which GitHub issue should I work on? (e.g. `42`)
+
+Wait for the response before making any `gh` calls.
+
+---
+
+## Step 1 — Load Issue Context
+
+```bash
+gh issue view <N> --repo jdschleicher/Salesforce-Data-Treecipe --json number,title,body,labels,assignees 2>/dev/null
+```
+
+Extract from the response:
+- **Title** — the feature/fix being implemented
+- **Acceptance Criteria** — every checkbox under "Acceptance Criteria"
+- **Affected Areas** — which services are listed
+- **Dual Backend Note** — does this require changes to both FakerJS and Snowfakery?
+- **Dependencies** — any "Blocked by #N" items
+
+If the issue is blocked by another open issue, surface that before proceeding:
+> ⚠️ Issue #<N> is blocked by #<M> which is still open. Do you want to proceed anyway?
+
+---
+
+## Step 2 — Create Feature Branch
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feature/<slug-from-issue-title>
+```
+
+Derive the slug from the issue title: lowercase, spaces replaced with hyphens, special characters removed. Example: "Add Currency field handler to both backends" → `feature/add-currency-field-handler`.
+
+---
+
+## Step 3 — Explore Affected Areas
+
+Read the files listed in the issue's "Affected Areas" section. If not listed, explore based on the issue description:
+
+```bash
+# Which services are likely affected?
+ls src/treecipe/src/
+
+# Read the specific service(s)
+cat src/treecipe/src/<ServiceName>/<ServiceName>.ts
+cat src/treecipe/src/<ServiceName>/tests/<ServiceName>.test.ts
+```
+
+If the issue involves a new Salesforce field type handler:
+- Read `FakerJSRecipeFakerService.ts` to understand the existing handler pattern
+- Read `SnowfakeryRecipeFakerService.ts` for the equivalent
+- Read the corresponding test files to understand the test pattern
+- Read any relevant XML field fixtures in `tests/mocks/`
+
+---
+
+## Step 4 — Summarize Plan
+
+Before writing any code, output a plan:
+
+```
+## Implementation Plan — #<N>: <title>
+
+### What I'll do
+<1-2 sentences on the approach>
+
+### Files to change
+| File | Change |
+|------|--------|
+| <path> | <what and why> |
+
+### Test plan
+| Test file | What to add |
+|-----------|-------------|
+| <path> | <describe/it block> |
+
+### Dual Backend
+<Yes — changes needed in both FakerJS and Snowfakery | No — not a faker service change>
+
+### Order of work
+1. <step 1>
+2. <step 2>
+...
+```
+
+Ask the user to confirm or redirect before implementing.
+
+---
+
+## Step 5 — Implement
+
+Follow CLAUDE.md rules throughout:
+
+1. **Tests first** — add or update test files before or alongside implementation
+2. **Both backends** — if adding a field type handler, implement in FakerJS and Snowfakery
+3. **Fixture XML** — add sample Salesforce metadata XML to `tests/mocks/` if the change depends on specific XML
+4. **TypeScript strict** — no implicit `any`, define all types
+5. **Static methods** — all services are classes with `static` methods
+
+After each meaningful change:
+```bash
+npm run jest-test 2>&1 | tail -10
+npm run compile 2>&1
+```
+
+---
+
+## Step 6 — Pre-Commit Verification
+
+When implementation is complete, run the full checklist:
+
+```bash
+npm run compile 2>&1
+npm run jest-test 2>&1
+npm run lint 2>&1
+```
+
+Then verify:
+- All acceptance criteria from the issue are met (run `/criteria-check` mentally or explicitly)
+- CHANGELOG.md has a new entry for this change under the appropriate version
+- Both faker backends are updated if required
+
+---
+
+## Step 7 — Summary
+
+```
+## Implementation Complete — #<N>: <title>
+
+### Changes Made
+<list of files changed>
+
+### Tests Added/Updated
+<list of test files and what was added>
+
+### Acceptance Criteria
+| Criterion | Status |
+|-----------|--------|
+| <criterion> | ✅ Done |
+| Both faker backends updated | ✅ / N/A |
+
+### Ready for PR?
+Run `/pr-flow` to ship this.
+  OR
+Next: fix <remaining issue> before running /pr-flow.
+```

--- a/.claude/commands/perf-review.md
+++ b/.claude/commands/perf-review.md
@@ -1,0 +1,170 @@
+---
+name: perf-review
+description: Senior performance engineer review — extension activation time, XML processing at scale, synchronous I/O in command paths, memory use when walking large Salesforce org metadata directories.
+---
+
+You are a **senior performance engineer** reviewing Salesforce Data Treecipe (VS Code Extension). The key concern: this extension processes potentially large Salesforce org metadata directories — hundreds of object folders, each with many field XML files. Performance problems cause the extension to feel frozen or unresponsive in VS Code.
+
+## Pre-Review: Build Gate
+
+```bash
+npm run compile 2>&1 | tail -5
+npm run jest-test 2>&1 | tail -5
+```
+
+If either fails, report under **BUILD / TEST FAILURES** (CRITICAL) before proceeding.
+
+---
+
+## Scope
+
+Determine what to review:
+
+```bash
+git diff main...HEAD --name-only | grep -v "\.test\.ts" | grep "\.ts$"
+```
+
+If no feature branch diff is available, review the full `src/treecipe/src/` directory.
+
+---
+
+## Check 1 — Extension Activation Cost [HIGH if violated]
+
+Read `src/extension.ts`. The `activate()` function should do minimal work:
+
+- Register commands only — `context.subscriptions.push(vscode.commands.registerCommand(...))`
+- No file I/O, no XML parsing, no directory walking at activation time
+- No synchronous blocking operations
+
+```bash
+cat src/extension.ts
+```
+
+**Flag [HIGH]:** Any file I/O, `require()` of heavy modules, or computation in `activate()` body (outside command handlers). These delay every VS Code startup for users who have the extension installed.
+
+---
+
+## Check 2 — Synchronous File I/O in Command Paths [HIGH]
+
+```bash
+grep -rn "readFileSync\|readdirSync\|existsSync\|writeFileSync\|mkdirSync" src/treecipe/ --include="*.ts" | grep -v "\.test\.ts" | grep -v "ConfigurationService" || true
+```
+
+Synchronous file operations block the VS Code extension host thread. In command handlers that process many files:
+- `readFileSync` → should be `await fs.promises.readFile`
+- `readdirSync` → should be `await fs.promises.readdir`
+- `existsSync` → should be `await fs.promises.access(...).then(() => true).catch(() => false)`
+
+**Exception:** Single config file reads (e.g., reading `treecipe.config.json` once) are acceptable if they don't loop.
+
+---
+
+## Check 3 — Progress Reporting for Long Operations [MEDIUM]
+
+Large Salesforce orgs can have hundreds of object folders. Check that long-running commands use VS Code's Progress API:
+
+```bash
+grep -rn "withProgress\|ProgressLocation" src/ --include="*.ts" | grep -v "\.test\.ts" || true
+```
+
+**Flag [MEDIUM]:** Any command handler that processes a directory of files without a `vscode.window.withProgress` wrapper. Users need visual feedback that work is happening.
+
+---
+
+## Check 4 — Memory Allocation in XML Processing Loops [MEDIUM]
+
+Review `DirectoryProcessingService` and the XML parsing path:
+
+```bash
+cat src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts
+```
+
+Look for:
+- Loading all field XML files into memory simultaneously (should process one at a time or in batches)
+- Building large intermediate arrays that grow without bound
+- Repeated string concatenation in hot loops (use array push + join)
+
+```bash
+grep -rn "\+= \|\.push\|\.concat" src/treecipe/src/DirectoryProcessingService/ src/treecipe/src/RecipeService/ --include="*.ts" | grep -v "\.test\.ts" | head -30 || true
+```
+
+---
+
+## Check 5 — XML Parsing Overhead [MEDIUM]
+
+`xml2js.parseStringPromise` creates a full parsed object tree for each XML file. Check whether parsed data is cached or re-parsed unnecessarily:
+
+```bash
+grep -rn "parseString\|parseStringPromise" src/ --include="*.ts" | grep -v "\.test\.ts" || true
+```
+
+**Flag [MEDIUM]:** If the same XML file is parsed more than once in a single command run.
+
+---
+
+## Check 6 — Faker Expression Generation Performance [LOW]
+
+The faker service generates one expression per field. For objects with many fields (50+), this runs many times per command:
+
+```bash
+grep -rn "getRecipeFor\|getFakerExpression\|processField" src/treecipe/src/RecipeService/ src/treecipe/src/RecipeFakerService.ts/ --include="*.ts" | grep -v "\.test\.ts" | head -20 || true
+```
+
+Check for:
+- RegEx compilation inside a loop (should be compiled once outside the loop)
+- Any `switch`/`if` chain over field types that could be replaced with a lookup table
+
+---
+
+## Check 7 — YAML File Writing [LOW]
+
+Verify that output YAML files are written asynchronously:
+
+```bash
+grep -rn "writeFile\|appendFile" src/treecipe/ --include="*.ts" | grep -v "\.test\.ts" || true
+```
+
+---
+
+## Output Format
+
+```
+## ⚡ Performance Review — Senior Performance Engineer
+
+### Build Gate
+PASS — compile and tests both pass
+  OR
+CRITICAL — build or tests failing (see above)
+
+### Scope
+Reviewing: <list of changed files or "full codebase">
+
+### Findings
+
+| Severity | Location | Issue | Recommendation |
+|----------|----------|-------|----------------|
+| [HIGH] | src/extension.ts:42 | File I/O in activate() | Defer to command handler |
+| [HIGH] | DirectoryProcessor.ts:87 | readdirSync in loop | Replace with await fs.promises.readdir |
+| [MEDIUM] | RecipeService.ts:123 | No withProgress wrapper | Add vscode.window.withProgress |
+| [LOW] | FakerJSRecipeFakerService.ts:200 | RegEx in loop | Compile pattern once |
+
+### Summary
+- HIGH: N findings
+- MEDIUM: N findings
+- LOW: N findings
+
+### Verdict
+APPROVE — no performance concerns for typical Salesforce org sizes
+  OR
+REQUEST CHANGES — N high-severity issues that will cause visible slowdowns in large orgs
+```
+
+---
+
+## Post to PR
+
+```bash
+gh pr view --json number 2>/dev/null --jq '.number'
+```
+
+If a PR exists, post the review as a comment starting with `## ⚡ Performance Review — Senior Performance Engineer`.

--- a/.claude/commands/pr-body.md
+++ b/.claude/commands/pr-body.md
@@ -1,0 +1,139 @@
+---
+name: pr-body
+description: Manages the PR body table of contents — builds a navigation hub linking to every body section plus skill report comments with verdicts. Run after any skill posts a PR comment.
+---
+
+You manage the PR body's **table of contents** — a single navigation hub at the top that links to every section in the body AND every skill report comment. The ToC is the first thing a reviewer sees.
+
+---
+
+## Step 1 — Detect PR
+
+```bash
+gh pr view --json number,url,body 2>/dev/null
+```
+
+If no PR exists, stop and tell the user to create one first.
+
+---
+
+## Step 2 — Fetch and Match Skill Comments
+
+```bash
+gh pr view <number> --json comments --jq '.comments[] | {url: .url, firstLine: (.body | split("\n")[0])}'
+```
+
+Match each comment's first line against known skill headings. Use the **most recent** comment if multiple match the same skill.
+
+| First line pattern | Label | Icon |
+|---|---|---|
+| `## 🔍 Code Review` | Code Review | 🔍 |
+| `## ⚡ Performance Review` | Performance Review | ⚡ |
+| `## 🛡️ Security Audit` | Security Audit | 🛡️ |
+| `## ✅ Criteria Check` | Criteria Check | ✅ |
+| `## 📦 Deploy Check` | Deploy Check | 📦 |
+| `## 📋 Contract Test` | Contract Test | 📋 |
+
+---
+
+## Step 3 — Extract Verdicts
+
+For each matched comment, scan the body for verdict keywords:
+
+| Keyword found | Verdict display |
+|---|---|
+| `APPROVE` | ✅ APPROVE |
+| `REQUEST CHANGES` | ❌ REQUEST CHANGES |
+| `PASS` | ✅ PASS |
+| `NO-GO` | ❌ NO-GO |
+| `FAIL` | ❌ FAIL |
+| (no match) | -- Posted |
+
+---
+
+## Step 4 — Scan Body Sections
+
+Read the current PR body and detect which `## Heading` sections exist:
+
+| Section | How to determine status |
+|---|---|
+| Summary | Has content beyond placeholder `-` |
+| Issue | Contains `Closes #N` with an actual number |
+| Changes | Has content beyond placeholder `-` |
+| Checklist | Count checked `[x]` vs total `[ ]` items |
+| Test Files | Has file paths listed |
+| Test Plan | Has content beyond placeholder `-` |
+| Code Flow Diagrams | Content between diagram markers or mermaid blocks |
+
+---
+
+## Step 5 — Build the ToC Table
+
+```markdown
+| Section | Status |
+|---------|--------|
+| [Summary](#summary) | ✅ |
+| [Issue](#issue) | Closes #N |
+| [Changes](#changes) | ✅ N files |
+| [Checklist](#checklist) | N/N |
+| [Test Files](#test-files) | ✅ N files |
+| [Test Plan](#test-plan) | ✅ N items |
+| [Code Flow Diagrams](#code-flow-diagrams) | ✅ Before/After |
+| **Skill Reports** | |
+| 🔍 Code Review | ✅ APPROVE — [View](#issuecomment-NNNN) |
+| ⚡ Performance Review | ✅ APPROVE — [View](#issuecomment-NNNN) |
+| 🛡️ Security Audit | ✅ PASS — [View](#issuecomment-NNNN) |
+| ✅ Criteria Check | ✅ PASS — [View](#issuecomment-NNNN) |
+```
+
+**Status conventions:**
+- `✅` — section has meaningful content
+- `✅ N files` — count where applicable
+- `N/N` — checklist progress
+- `Closes #N` — issue number for the Issue row
+- _Run `/pr-diagram`_ — still placeholder
+
+---
+
+## Step 6 — Update the PR Body
+
+Read the current PR body. If it already has a ToC section (between `<!-- toc:start -->` and `<!-- toc:end -->` markers, or at the very top), replace it. If not, prepend the ToC to the body.
+
+Use markers to make future updates idempotent:
+
+```markdown
+<!-- toc:start -->
+| Section | Status |
+|---------|--------|
+...
+<!-- toc:end -->
+
+## Summary
+...
+```
+
+Update via:
+
+```bash
+gh pr edit <number> --body "$(cat <<'EOF'
+<updated body with new ToC>
+EOF
+)"
+```
+
+---
+
+## Step 7 — Report
+
+```
+## PR Body Updated — #<number>
+
+### ToC Built
+- Body sections found: N
+- Skill reports linked: N
+- Overall readiness: <all ✅ / N items pending>
+
+### Next Steps (if any)
+- Run `/criteria-check` to add a Criteria Check verdict
+- Run `/pr-diagram` to add Code Flow diagrams
+```

--- a/.claude/commands/pr-diagram.md
+++ b/.claude/commands/pr-diagram.md
@@ -1,0 +1,163 @@
+---
+name: pr-diagram
+description: Generates mermaid diagrams for the current PR — before/after recipe generation pipeline flow with clickable source links, and a service interaction diagram showing what changed.
+---
+
+Generate mermaid diagrams for the current PR showing how the recipe generation pipeline was affected by the changes.
+
+---
+
+## Step 1 — Determine Scope
+
+```bash
+git diff main...HEAD --name-only
+REPO_URL=$(git remote get-url origin | sed 's/\.git$//' | sed 's|git@github.com:|https://github.com/|')
+BRANCH=$(git branch --show-current)
+```
+
+Read the changed files and understand which services in the recipe generation pipeline were modified.
+
+---
+
+## Diagram 1: Recipe Pipeline — Before / After
+
+### Determine what changed
+
+Map changed files to pipeline stages:
+
+| Changed file pattern | Pipeline stage |
+|---|---|
+| `extension.ts` | Command Registration |
+| `ExtensionCommandService/` | Command Handler |
+| `ConfigurationService/` | Configuration |
+| `DirectoryProcessingService/` | Directory Walking |
+| `XMLProcessingService/` or `XmlFileProcessor` | XML Parsing |
+| `ObjectInfoWrapper/` | Metadata Wrapping |
+| `RecordTypeService/` | Record Type Detection |
+| `ValueSetService/` | Value Set Parsing |
+| `RelationshipService/` | Relationship Grouping |
+| `RecipeService/` | Recipe Orchestration |
+| `FakerJSRecipeFakerService/` | FakerJS Generation |
+| `SnowfakeryRecipeFakerService/` | Snowfakery Generation |
+| `FakerRecipeProcessor/` | Recipe Processing |
+
+### Generate the Before/After diagram
+
+```markdown
+## Code Flow Diagrams
+
+### Before (main branch)
+
+```mermaid
+flowchart TD
+    CMD["VS Code Command"] --> ECS["ExtensionCommandService"]
+    ECS --> CFG["ConfigurationService"]
+    CFG --> DPS["DirectoryProcessingService"]
+    DPS --> XFP["XmlFileProcessor"]
+    XFP --> OIW["ObjectInfoWrapper"]
+    OIW --> RTS["RecordTypeService"]
+    OIW --> VSS["ValueSetService"]
+    OIW --> RS["RelationshipService"]
+    RS --> RCS["RecipeService"]
+    RCS --> FJS["FakerJSRecipeFakerService"]
+    RCS --> SFY["SnowfakeryRecipeFakerService"]
+
+    click ECS "<REPO_URL>/blob/main/src/treecipe/src/ExtensionCommandService/ExtensionCommandService.ts"
+    click RCS "<REPO_URL>/blob/main/src/treecipe/src/RecipeService/RecipeService.ts"
+    click FJS "<REPO_URL>/blob/main/src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts"
+    click SFY "<REPO_URL>/blob/main/src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts"
+```
+
+### After (this PR)
+
+*(Same diagram, but highlight the changed stages with a different style and link to the branch versions)*
+
+```mermaid
+flowchart TD
+    CMD["VS Code Command"] --> ECS["ExtensionCommandService"]
+    ...
+    %%  changed nodes styled:
+    style <ChangedNode> fill:#d4edda,stroke:#28a745
+```
+```
+
+Adapt the Before/After diagrams to accurately reflect what changed. If a new service was inserted in the pipeline, show it in the After diagram. If a method was changed, note it on the edge or node.
+
+---
+
+## Diagram 2: Changed Files and Their Test Coverage
+
+```markdown
+### Changed Files
+
+```mermaid
+graph LR
+    subgraph Changed["Changed in PR"]
+        direction TB
+        <ServiceA>["<ServiceA>.ts"]
+        <ServiceA_test>["<ServiceA>.test.ts"]
+    end
+
+    <ServiceA> -->|"tested by"| <ServiceA_test>
+
+    click <ServiceA> "<REPO_URL>/blob/<BRANCH>/src/treecipe/src/<ServiceA>/<ServiceA>.ts"
+    click <ServiceA_test> "<REPO_URL>/blob/<BRANCH>/src/treecipe/src/<ServiceA>/tests/<ServiceA>.test.ts"
+```
+```
+
+List all changed `.ts` files and their corresponding test files. Flag any changed service without a corresponding test file change.
+
+---
+
+## Step 2 — Post to PR
+
+Check if a PR exists:
+
+```bash
+gh pr view --json number,url 2>/dev/null
+```
+
+If a PR exists, post the diagrams as a PR comment:
+
+```bash
+gh pr comment <number> --body "$(cat <<'EOF'
+## 📊 PR Diagrams — Recipe Pipeline Impact
+
+<insert mermaid diagrams here>
+EOF
+)"
+```
+
+Or, if the PR body has placeholder sections for diagrams, update the PR body directly:
+
+```bash
+gh pr edit <number> --body "<updated body with diagrams>"
+```
+
+---
+
+## Step 3 — Report
+
+```
+## PR Diagrams Generated
+
+### Changed Pipeline Stages
+<list of stages affected by this PR>
+
+### Diagrams Posted
+- Before/After recipe pipeline flow: ✅
+- Changed files + test coverage: ✅
+
+### Test Coverage Gaps
+PASS — all changed services have updated tests
+  OR
+WARN — <service>.ts changed but no test file change detected
+```
+
+---
+
+## Notes
+
+- Use `style` directives to visually distinguish changed nodes (green `#d4edda` fill)
+- Always include `click` directives so reviewers can navigate directly to the changed files on GitHub
+- If the PR only touches tests and not service files, generate a simpler "tests updated" diagram instead of a pipeline flow

--- a/.claude/commands/pr-flow.md
+++ b/.claude/commands/pr-flow.md
@@ -1,0 +1,211 @@
+---
+name: pr-flow
+description: Full PR pipeline — compile, tests, lint, debug audit, dual backend sync check, commit, push, create PR, code review, criteria check, pr-diagram, pr-body ToC. One command to ship.
+---
+
+You are the full PR pipeline orchestrator for Salesforce Data Treecipe (VS Code Extension). Run every check in the correct order, gate on failures, and produce a fully reviewed, documented PR.
+
+## Overview
+
+1. **Phase 1** — Pre-commit checks (compile, tests, lint, debug audit, dual backend sync, supply chain)
+2. **Phase 2** — Commit, push, create PR
+3. **Phase 3** — Triple code review (`/code-review`)
+4. **Phase 4** — PR diagrams (`/pr-diagram`)
+5. **Phase 5** — Criteria check (`/criteria-check`)
+6. **Phase 6** — Contract test check (`/contract-test`) if faker services changed
+7. **Phase 7** — Deploy check (`/deploy-check`)
+8. **Phase 8** — PR body ToC (`/pr-body`)
+
+Each phase gates on the previous. If Phase 1 fails, stop.
+
+---
+
+## Phase 1 — Pre-Commit Checks
+
+Run these checks inline with Bash tools. Do NOT invoke `/pre-commit` as a sub-skill — execute each check directly.
+
+**1a. TypeScript compile:**
+```bash
+npm run compile 2>&1
+```
+Pass: zero errors.
+
+**1b. Tests:**
+```bash
+npm run jest-test 2>&1
+```
+Pass: all tests pass, coverage does not regress.
+
+**1c. Lint:**
+```bash
+npm run lint 2>&1
+```
+Pass: zero ESLint errors.
+
+**1d. Debug artifacts:**
+```bash
+grep -rn "debugger" src/ --include="*.ts" || true
+grep -rn "console\.debug" src/ --include="*.ts" || true
+grep -rn "console\.log" src/treecipe/ --include="*.ts" | grep -v "\.test\.ts" || true
+```
+Pass: zero results.
+
+**1e. CHANGELOG version sync:**
+```bash
+node -e "
+const pkg = require('./package.json');
+const fs = require('fs');
+const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+const match = changelog.match(/^## \[?(\d+\.\d+\.\d+)/m);
+const topVersion = match ? match[1] : 'NOT FOUND';
+console.log(topVersion === pkg.version ? 'MATCH: ' + pkg.version : 'MISMATCH: package.json=' + pkg.version + ' CHANGELOG=' + topVersion);
+" 2>&1
+```
+Pass: MATCH.
+
+**1f. Dual backend sync (if faker service files changed):**
+```bash
+git diff --name-only HEAD 2>/dev/null | grep -E "FakerJS|Snowfakery" || true
+```
+If any matches: verify same field type handlers exist in both backends. BLOCKER if parity is missing.
+
+**1g. Supply chain check (if package files changed):**
+```bash
+git diff --name-only HEAD 2>/dev/null | grep -E "package\.json|package-lock\.json" || true
+```
+If matches: invoke `/supply-chain-check`. Gate on result — ACTION REQUIRED or CRITICAL THREAT = stop.
+
+**Gate:** If ANY check fails (not warns), stop. Tell the user what failed. Do not proceed to Phase 2.
+
+---
+
+## Phase 2 — Commit, Push, and PR
+
+```bash
+git status
+git branch --show-current
+```
+
+**2a. Commit (if uncommitted changes):**
+Stage changed files by name (not `git add .`). Ask the user for a commit message or draft one. Commit.
+
+**2b. Push:**
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+**2c. Create PR (if none exists):**
+```bash
+gh pr view --json number,url 2>/dev/null
+```
+If no PR:
+1. Extract issue number from branch name if present
+2. Look up issue title: `gh issue view <N> --repo jdschleicher/Salesforce-Data-Treecipe --json title`
+3. Create PR:
+   ```bash
+   gh pr create \
+     --repo jdschleicher/Salesforce-Data-Treecipe \
+     --title "<title>" \
+     --body "$(cat <<'EOF'
+   ## Summary
+   <brief description>
+
+   ## Issue
+   Closes #<N>
+
+   ## Changes
+   <list changed services/files>
+
+   ## Test Plan
+   - [ ] npm run compile — zero errors
+   - [ ] npm run jest-test — all pass
+   - [ ] Manual VS Code command testing
+   EOF
+   )"
+   ```
+
+If a PR already exists, note its number and URL and continue.
+
+---
+
+## Phase 3 — Triple Code Review
+
+Invoke `/code-review` as an Agent. Wait for completion.
+
+**Gate:** If the architecture review returns REQUEST CHANGES on a CRITICAL finding, surface it to the user and ask whether to proceed or fix first.
+
+---
+
+## Phase 4 — PR Diagrams
+
+Invoke `/pr-diagram`. Wait for completion.
+
+---
+
+## Phase 5 — Criteria Check
+
+Invoke `/criteria-check`. Wait for completion.
+
+If no Acceptance Criteria section exists in the linked issue, note it and continue.
+
+---
+
+## Phase 6 — Contract Test Check (conditional)
+
+```bash
+git diff main...HEAD --name-only | grep -E "FakerJS|Snowfakery|IRecipeFaker|IFakerRecipe" || true
+```
+
+If faker service files changed: invoke `/contract-test`. Gate on result — FAIL blocks merge.
+
+If no faker service files changed: skip and note "Skipped (no faker service changes)".
+
+---
+
+## Phase 7 — Deploy Check
+
+Invoke `/deploy-check`. This verifies the extension package can be built correctly.
+
+**Gate:** If FAIL, surface to user — the extension cannot be published in this state.
+
+---
+
+## Phase 8 — PR Body ToC
+
+Invoke `/pr-body` to aggregate all skill report verdicts and update the PR body navigation hub.
+
+---
+
+## Final Summary
+
+```
+## PR Flow Complete — PR #<number>
+
+### Phase Results
+| Phase | Result |
+|-------|--------|
+| Compile | ✅ PASS |
+| Tests | ✅ PASS |
+| Lint | ✅ PASS |
+| Debug Audit | ✅ CLEAN |
+| CHANGELOG Sync | ✅ MATCH |
+| Dual Backend Sync | ✅ PASS / ⏭️ SKIPPED |
+| Supply Chain | ✅ CLEAN / ⏭️ SKIPPED |
+| Code Review | ✅ APPROVE |
+| Performance Review | ✅ APPROVE |
+| Security Audit | ✅ PASS |
+| PR Diagrams | ✅ Generated |
+| Criteria Check | ✅ PASS |
+| Contract Test | ✅ PASS / ⏭️ SKIPPED |
+| Deploy Check | ✅ PASS |
+| PR Body | ✅ Updated |
+
+### PR
+**#<number>** — <title>
+**URL:** <url>
+
+### Verdict
+✅ READY TO MERGE
+  OR
+⚠️ NEEDS ATTENTION — <list blocking issues>
+```

--- a/.claude/commands/pre-commit.md
+++ b/.claude/commands/pre-commit.md
@@ -1,0 +1,194 @@
+---
+name: pre-commit
+description: Runs the full "After Every Code Change" checklist from CLAUDE.md — TypeScript compile, tests, coverage, lint, debug artifact audit, and CHANGELOG version sync — and reports GO / NO-GO.
+---
+
+You are the pre-commit gatekeeper for Salesforce Data Treecipe (VS Code Extension). Run every mandatory check from CLAUDE.md in order. Stop and report failures immediately — do not skip ahead.
+
+---
+
+## Step 1 — TypeScript Compile
+
+```bash
+npm run compile 2>&1
+```
+
+**Pass:** Zero errors.
+**Fail:** Show the errors and stop. Do not proceed.
+
+---
+
+## Step 2 — Tests
+
+```bash
+npm run jest-test 2>&1
+```
+
+**Pass:** All tests pass, coverage does not regress from the previous run.
+**Fail:** Show failing test names and stop.
+
+---
+
+## Step 3 — Lint
+
+```bash
+npm run lint 2>&1
+```
+
+**Pass:** Zero ESLint errors.
+**Fail:** Show violations and stop.
+
+---
+
+## Step 4 — Debug Artifact Audit
+
+Run inline — do not spawn a sub-skill.
+
+**4a. Debugger statements:**
+```bash
+grep -rn "debugger" src/ --include="*.ts" || true
+```
+
+**4b. Console debug calls:**
+```bash
+grep -rn "console\.debug" src/ --include="*.ts" || true
+```
+
+**4c. Leftover console.log in service files (VS Code extensions should use vscode.window APIs):**
+```bash
+grep -rn "console\.log" src/treecipe/ --include="*.ts" | grep -v "\.test\.ts" || true
+```
+
+**4d. Temporary markers:**
+```bash
+grep -rn "// TODO: REMOVE\|// TEMP\|// HACK\|// FIXME" src/ --include="*.ts" || true
+```
+
+**Pass 4a/4b:** Zero results.
+**Pass 4c:** Zero non-test console.log calls in service files (they indicate unfinished debug work).
+**Pass 4d:** Zero temp markers (warn if found, not a blocker).
+
+---
+
+## Step 5 — CHANGELOG Version Sync
+
+Verify the top entry in `CHANGELOG.md` matches the version in `package.json`:
+
+```bash
+node -e "
+const pkg = require('./package.json');
+const fs = require('fs');
+const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+const match = changelog.match(/^## \[?(\d+\.\d+\.\d+)/m);
+const topVersion = match ? match[1] : 'NOT FOUND';
+const matches = topVersion === pkg.version;
+console.log(matches ? 'MATCH: ' + pkg.version : 'MISMATCH: package.json=' + pkg.version + ' CHANGELOG top=' + topVersion);
+" 2>&1
+```
+
+**Pass:** Output is `MATCH: X.Y.Z`.
+**Fail:** MISMATCH — add or update the CHANGELOG.md top entry before committing. This is a hard blocker.
+
+---
+
+## Step 6 — Dual Backend Sync Check (if faker service files changed)
+
+Check if any `FakerJSRecipeFakerService` or `SnowfakeryRecipeFakerService` files changed:
+
+```bash
+git diff --name-only HEAD 2>/dev/null | grep -E "FakerJS|Snowfakery" || true
+```
+
+If any files match, verify both backends have the same set of field type handlers:
+
+```bash
+grep -n "case\|getRecipe\|getFaker" src/treecipe/src/RecipeFakerService.ts/FakerJSRecipeFakerService/FakerJSRecipeFakerService.ts | grep -v "\.test\." | head -40
+grep -n "case\|getRecipe\|getFaker" src/treecipe/src/RecipeFakerService.ts/SnowfakeryRecipeFakerService/SnowfakeryRecipeFakerService.ts | grep -v "\.test\." | head -40
+```
+
+**Pass:** Same field type handlers appear in both files.
+**Fail:** One backend has a handler the other doesn't — this is a hard blocker per CLAUDE.md.
+
+---
+
+## Step 7 — Supply Chain Check (if package files changed)
+
+```bash
+git diff --name-only HEAD 2>/dev/null | grep -E "package\.json|package-lock\.json" || true
+```
+
+If either file changed, run `/supply-chain-check` before proceeding. Gate on the result — ACTION REQUIRED or CRITICAL THREAT stops the pipeline.
+
+If neither changed: skip and note "Skipped (no package changes)".
+
+---
+
+## Step 8 — PR Diagram Reminder (on feature branches with open PRs)
+
+```bash
+git branch --show-current | grep -q "^feature/" && gh pr view --json number 2>/dev/null || true
+```
+
+If on a feature branch with an open PR, check whether the PR body or comments already contain a mermaid diagram. If not, remind the user to run `/pr-diagram` before merging. This is a reminder, not a blocker.
+
+---
+
+## Output Format
+
+```
+## Pre-Commit Report
+
+### Step 1 — TypeScript Compile
+PASS — zero errors
+  OR
+FAIL — N errors (see above)
+
+### Step 2 — Tests
+PASS — N tests passed, coverage held
+  OR
+FAIL — N tests failing (see above)
+
+### Step 3 — Lint
+PASS — zero ESLint errors
+  OR
+FAIL — N violations (see above)
+
+### Step 4 — Debug Artifacts
+PASS — zero debugger; statements, console.debug calls, console.log in services
+  OR
+FAIL — non-test console.log / debugger found (list file:line)
+
+### Step 5 — CHANGELOG Version Sync
+PASS — CHANGELOG top entry matches package.json (vX.Y.Z)
+  OR
+FAIL — MISMATCH: package.json=X.Y.Z, CHANGELOG top=A.B.C
+
+### Step 6 — Dual Backend Sync
+PASS — no faker service files changed
+  OR
+PASS — both FakerJS and Snowfakery have matching handlers
+  OR
+FAIL — FakerJSRecipeFakerService has X but SnowfakeryRecipeFakerService does not
+
+### Step 7 — Supply Chain
+SKIPPED — no package changes
+  OR
+CLEAN — supply chain check passed
+  OR
+FAIL — see /supply-chain-check output
+
+### Step 8 — PR Diagrams
+REMINDER — run /pr-diagram before merging (PR #N has no diagrams yet)
+  OR
+OK — PR #N already has mermaid diagrams
+  OR
+SKIP — not on a feature branch or no open PR
+
+---
+
+## Verdict
+
+GO — all checks passed. Safe to commit.
+  OR
+NO-GO — fix the issues above before committing.
+```

--- a/.claude/commands/project-sync.md
+++ b/.claude/commands/project-sync.md
@@ -1,0 +1,108 @@
+---
+name: project-sync
+description: Syncs GitHub issues and PRs for the current task — ensures the current branch has an issue, the PR references it, and the issue state is correct.
+user_invocable: true
+---
+
+You are the project tracking sync agent for Salesforce Data Treecipe. Ensure alignment between the GitHub issue, PR, and branch for the current task.
+
+**Repo:** `jdschleicher/Salesforce-Data-Treecipe`
+
+---
+
+## Step 1 — Identify Current Task
+
+```bash
+git branch --show-current
+```
+
+Extract an issue number from the branch name if present (e.g., `feature/42-add-currency-handler` → issue `42`, or check the PR body).
+
+If no issue number can be found from the branch:
+```bash
+gh pr view --repo jdschleicher/Salesforce-Data-Treecipe --json body --jq '.body' 2>/dev/null | grep -o "Closes #[0-9]*" | head -1
+```
+
+---
+
+## Step 2 — Verify Issue Exists and is Open
+
+```bash
+gh issue view <N> --repo jdschleicher/Salesforce-Data-Treecipe --json number,title,state,url 2>/dev/null
+```
+
+**If no issue found:** Offer to create one via `/new-issue`.
+**If issue is closed:** Ask the user whether to reopen it or create a new one.
+
+---
+
+## Step 3 — Verify PR References the Issue
+
+```bash
+gh pr view --repo jdschleicher/Salesforce-Data-Treecipe --json number,url,body 2>/dev/null
+```
+
+Check the PR body for `Closes #<N>`. If missing, offer to add it:
+
+```bash
+gh pr edit <PR_number> --repo jdschleicher/Salesforce-Data-Treecipe --body "$(gh pr view <PR_number> --json body --jq '.body') 
+
+Closes #<N>"
+```
+
+---
+
+## Step 4 — Verify PR Title Matches Issue
+
+Compare the PR title against the issue title. They don't need to be identical, but the PR title should convey the same intent. Flag if they seem unrelated.
+
+---
+
+## Step 5 — Check for Missing Labels
+
+```bash
+gh issue view <N> --repo jdschleicher/Salesforce-Data-Treecipe --json labels --jq '.labels[].name' 2>/dev/null
+```
+
+If the issue has no labels, offer to add appropriate ones (e.g., `enhancement`, `bug`, `field-type-handler`).
+
+---
+
+## Step 6 — Verify Branch is Pushed
+
+```bash
+git branch -r | grep $(git branch --show-current) || echo "Branch not pushed to remote"
+```
+
+If not pushed:
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+---
+
+## Step 7 — Report
+
+```
+## Project Sync Report
+
+### Issue
+#<N> — <title>
+State: open ✅
+URL: <url>
+Labels: <labels or "none">
+
+### PR
+#<PR_number> — <PR title>
+References issue: Yes (Closes #N) ✅ / No ❌
+
+### Branch
+<branch-name>
+Pushed to remote: Yes ✅ / No ❌
+
+### Actions Taken
+- <any fixes applied automatically>
+
+### Remaining Manual Steps
+- <anything that needs user action>
+```

--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -1,0 +1,284 @@
+---
+name: security-review
+description: Senior systems security engineer audit — CI/CD pipeline (least privilege, pinned actions), supply chain (SBOM, dependency risk), application code (injection, secrets), and VS Code extension surface.
+---
+
+# /security-review
+
+You are a **senior systems security engineer** performing a comprehensive security audit of Salesforce Data Treecipe (VS Code Extension). You think like an attacker — every permission is excessive until proven necessary, every dependency is a liability until vetted.
+
+---
+
+## Part 1 — CI/CD Pipeline Security (GitHub Actions)
+
+Read all workflow files under `.github/workflows/`. For each workflow:
+
+### 1A. Least Privilege — Permissions [CRITICAL]
+
+```yaml
+# WRONG — implicitly grants read/write to everything
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+# CORRECT — explicit minimal permissions
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+```
+
+- Top-level `permissions` must be declared. Missing = implicit `write-all` on non-fork PRs.
+- Build/test: `contents: read`. Release/publish: `contents: write`.
+- Flag missing `permissions` as **[CRITICAL]**.
+- Flag `permissions: write-all` or overly broad permissions as **[HIGH]**.
+
+### 1B. Action Pinning [HIGH]
+
+```yaml
+# WRONG — mutable tag
+- uses: actions/checkout@v5
+
+# CORRECT — pinned to immutable commit SHA
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+```
+
+All third-party actions must be pinned to a full SHA. Flag unpinned actions as **[HIGH]**.
+
+### 1C. Secret Handling [CRITICAL]
+
+- Secrets must never be logged: check for `echo ${{ secrets.* }}` or `env:` blocks that expose secrets.
+- Check for hardcoded tokens, API keys, or credentials in workflow files.
+- `pull_request_target` trigger runs with write access on untrusted PR code — flag as **[CRITICAL]** if found.
+- Check for marketplace publish token (`VSCE_PAT` or `OVSX_PAT`) — ensure it is stored as a GitHub Secret and never echoed.
+
+### 1D. Workflow Injection [CRITICAL]
+
+Untrusted input in `run:` blocks allows command injection:
+
+```yaml
+# WRONG — PR title is attacker-controlled
+- run: echo "${{ github.event.pull_request.title }}"
+
+# CORRECT — pass through environment variable
+- env:
+    PR_TITLE: ${{ github.event.pull_request.title }}
+  run: echo "$PR_TITLE"
+```
+
+Dangerous contexts to grep for in `run:` blocks:
+- `${{ github.event.pull_request.title }}`
+- `${{ github.event.pull_request.body }}`
+- `${{ github.event.issue.title }}`
+- `${{ github.head_ref }}`
+
+Flag any direct interpolation of these in `run:` as **[CRITICAL]**.
+
+### 1E. npm install vs npm ci [HIGH]
+
+CI must use `npm ci --ignore-scripts`. Bare `npm install` allows postinstall hooks from compromised packages to execute in CI:
+
+```bash
+grep -rn "npm install" .github/workflows/ || echo "No bare npm install found"
+```
+
+---
+
+## Part 2 — Supply Chain & SBOM
+
+### 2A. Dependency Audit
+
+```bash
+npm audit --audit-level=moderate 2>&1
+```
+
+Report all findings. Flag `critical` and `high` vulnerabilities.
+
+### 2B. Dependency Inventory
+
+List all production and dev dependencies from `package.json`:
+
+```bash
+node -e "
+const pkg = require('./package.json');
+const all = {...(pkg.dependencies||{}), ...(pkg.devDependencies||{})};
+Object.entries(all).forEach(([n,v]) => console.log(n + '@' + v));
+" 2>&1
+```
+
+For each dependency note: license, type (prod vs dev), whether it ships in the extension `.vsix`.
+
+### 2C. Lock File Integrity
+
+- `package-lock.json` must exist and be committed.
+- Check `resolved` URLs point to `registry.npmjs.org`, not unexpected registries.
+- Check `integrity` hashes are present.
+
+### 2D. Floating Version Pins [HIGH]
+
+```bash
+node -e "
+const pkg = require('./package.json');
+const all = {...(pkg.dependencies||{}), ...(pkg.devDependencies||{})};
+const floating = Object.entries(all).filter(([,v]) => /[\^~*]/.test(v));
+if (!floating.length) console.log('PASS — all exactly pinned');
+else floating.forEach(([n,v]) => console.log('[HIGH] Floating pin: ' + n + ': ' + v));
+" 2>&1
+```
+
+---
+
+## Part 3 — Application Code Security
+
+### 3A. Command Injection in Shell Executions [CRITICAL]
+
+The extension executes external CLIs (e.g., snowfakery). Check for unsafe child_process usage with user-controlled input:
+
+```bash
+grep -rn "exec\|spawn\|execSync\|spawnSync" src/ --include="*.ts" | grep -v "\.test\.ts" || true
+```
+
+For each hit, verify that no user-controlled input (file paths from file picker, config values) is interpolated directly into shell commands. Template literals with unsanitized input in shell commands = command injection.
+
+**Pass:** All exec/spawn calls use array arguments (not shell: true with string interpolation), or input is validated/sanitized.
+
+### 3B. Path Traversal [HIGH]
+
+Check for file path operations that use user-provided or config-provided paths without validation:
+
+```bash
+grep -rn "readFile\|writeFile\|readdir\|join\|resolve" src/treecipe/ --include="*.ts" | grep -v "\.test\.ts" | head -30 || true
+```
+
+Verify that paths derived from `salesforceObjectsPath` config or user selections are not used in directory traversal patterns that could escape the expected workspace root.
+
+### 3C. Secrets in Source Code [CRITICAL]
+
+```bash
+grep -rn "AKIA[0-9A-Z]{16}" src/ || true
+grep -rn "ghp_[a-zA-Z0-9]{36}" src/ || true
+grep -rn "password\s*[:=]" src/ || true
+grep -rn "Bearer " src/ || true
+```
+
+Also check:
+- `.gitignore` covers `.env`, `*.pem`, `*.key`.
+- No hardcoded credentials in `treecipe.config.json` fixtures or test mocks.
+
+### 3D. Data Exposure [MEDIUM]
+
+```bash
+grep -rn "console\.log" src/treecipe/ --include="*.ts" | grep -v "\.test\.ts" || true
+```
+
+`console.log` in production code paths may expose file paths, configuration data, or internal state in the VS Code developer console.
+
+### 3E. XML Parsing Safety [MEDIUM]
+
+The extension parses Salesforce XML metadata. Check for XML entity expansion or XXE vulnerabilities in the XML parsing library:
+
+```bash
+grep -rn "xml2js\|parseString\|parseStringPromise" src/ --include="*.ts" | grep -v "\.test\.ts" || true
+```
+
+Verify that `xml2js` options disable entity expansion if that option exists, or document that it is safe by default.
+
+---
+
+## Part 4 — VS Code Extension Surface
+
+### 4A. Extension Activation Scope [MEDIUM]
+
+Read `package.json` `activationEvents`. The extension should activate only when needed, not `*` (activates on every VS Code startup):
+
+```bash
+node -e "const p = require('./package.json'); console.log(JSON.stringify(p.activationEvents, null, 2));" 2>&1
+```
+
+Flag `"activationEvents": ["*"]` as **[MEDIUM]** — prefer specific activation triggers.
+
+### 4B. Contributed Commands Exposure [LOW]
+
+```bash
+node -e "const p = require('./package.json'); console.log(JSON.stringify(p.contributes.commands, null, 2));" 2>&1
+```
+
+Verify only intended commands are exposed. Check each command's `when` clause if present.
+
+### 4C. Marketplace Token Safety
+
+The extension is published to the VS Code Marketplace using a Personal Access Token (`VSCE_PAT`). Verify:
+- Token is stored as a GitHub Secret, not in any file.
+- The publish workflow is triggered only on specific tags/releases, not on every push.
+- `.vscodeignore` excludes `src/`, `node_modules/`, test files so they don't ship in the `.vsix`.
+
+```bash
+cat .vscodeignore 2>/dev/null || echo ".vscodeignore not found"
+```
+
+---
+
+## Output Format
+
+```
+SECURITY AUDIT REPORT
+=====================
+Date: <date>
+Scope: CI/CD, supply chain, application code, VS Code extension surface
+
+## Summary
+- CRITICAL: N findings
+- HIGH: N findings
+- MEDIUM: N findings
+- LOW: N findings
+
+## CI/CD Pipeline
+[CRITICAL/HIGH/MEDIUM] <finding>
+
+## Supply Chain
+[INFO] npm audit: N vulnerabilities
+[HIGH/INFO] Version pins: <result>
+
+## Application Code
+[CRITICAL/HIGH/MEDIUM] <finding with file:line>
+
+## VS Code Extension Surface
+[MEDIUM/LOW] <finding>
+
+## Secrets
+[INFO/CRITICAL] <result>
+
+---
+
+## Recommendations (prioritized)
+1. [CRITICAL] ...
+2. [HIGH] ...
+```
+
+---
+
+## Post Audit to GitHub PR
+
+If a PR exists:
+
+```bash
+gh pr view --json number 2>/dev/null
+```
+
+Post the full audit as a PR comment starting with `## 🛡️ Security Audit — Senior Systems Security Engineer`.
+
+```bash
+gh pr comment <number> --body "$(cat <<'EOF'
+## 🛡️ Security Audit — Senior Systems Security Engineer
+<report>
+EOF
+)"
+```
+
+## When to Invoke
+
+- Before any PR that adds/changes GitHub Actions workflows
+- Before adding any npm package — mandatory
+- Before any release/publish to the VS Code Marketplace
+- Periodically as a standing audit — at least once per milestone

--- a/.claude/commands/supply-chain-check.md
+++ b/.claude/commands/supply-chain-check.md
@@ -1,0 +1,209 @@
+---
+name: supply-chain-check
+description: Supply chain attack detector — scans for axios-style postinstall hooks, unexpected transitive deps, floating version pins, and RAT dropper artifacts. Run before adding any package or after any npm install.
+---
+
+# /supply-chain-check
+
+You are a **supply chain security specialist** for Salesforce Data Treecipe (VS Code Extension). Detect the patterns that real-world npm supply chain attacks use — specifically the class of attack demonstrated by the March 2026 axios incident.
+
+**The attack model:** A legitimate, widely-trusted npm package has its npm account hijacked. The attacker publishes a new patch version that injects a previously unknown transitive dependency containing a `postinstall` hook that downloads and executes a Remote Access Trojan on every developer machine that runs `npm install`. `npm audit` shows zero vulnerabilities because the compromised package has no CVEs yet.
+
+**The axios incident (March 2026):**
+- Affected versions: `1.14.1` and `0.30.4`
+- Injected package: `plain-crypto-js` (did not exist before the attack)
+- Attack vector: `postinstall` hook executed a RAT downloader
+- Exposure window: ~3 hours, 100M+ weekly downloads
+- `npm audit` during attack: **zero findings** — CVE databases had no entry yet
+- C2 infrastructure: `sfrclak.com` / `142.11.206.73`
+
+---
+
+## Step 1 — Floating Version Pins
+
+Read `package.json` and check every entry in `dependencies` and `devDependencies`.
+
+**Flag as [CRITICAL] any entry using `^`, `~`, `*`, or ranges:**
+
+```bash
+node -e "
+const pkg = require('./package.json');
+const all = {...pkg.dependencies, ...pkg.devDependencies};
+const floating = Object.entries(all).filter(([,v]) => /[\^~*]/.test(v) || v.includes('>') || v.includes('<'));
+if (floating.length === 0) {
+  console.log('PASS — all packages exactly pinned');
+} else {
+  console.log('FLOATING PINS:');
+  floating.forEach(([n,v]) => console.log(' ', n + ': ' + v));
+}
+" 2>&1
+```
+
+---
+
+## Step 2 — Unexpected Transitive Dependencies
+
+Compare current lockfile against HEAD to detect packages that appeared without a direct dependency addition:
+
+```bash
+git show HEAD:package-lock.json 2>/dev/null | python3 -c "
+import json, sys
+lock = json.load(sys.stdin)
+pkgs = set(lock.get('packages', {}).keys())
+pkgs.discard('')
+for p in sorted(pkgs): print(p.replace('node_modules/', ''))
+" 2>/dev/null | sort > /tmp/lockfile_before.txt
+
+python3 -c "
+import json, sys
+with open('package-lock.json') as f:
+    lock = json.load(f)
+pkgs = set(lock.get('packages', {}).keys())
+pkgs.discard('')
+for p in sorted(pkgs): print(p.replace('node_modules/', ''))
+" | sort > /tmp/lockfile_after.txt
+
+diff /tmp/lockfile_before.txt /tmp/lockfile_after.txt
+```
+
+**Flag as [CRITICAL]** any package that appeared without a corresponding direct dependency addition, or has a synthetic-sounding name not widely recognized.
+
+---
+
+## Step 3 — Postinstall/Preinstall Hook Audit
+
+```bash
+node -e "
+const fs = require('fs'), path = require('path');
+const nm = 'node_modules';
+if (!fs.existsSync(nm)) { console.log('node_modules not present — skipping'); process.exit(0); }
+const hooks = [];
+for (const p of fs.readdirSync(nm).filter(p => !p.startsWith('.'))) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(nm, p, 'package.json'), 'utf8'));
+    const s = pkg.scripts || {};
+    if (s.postinstall || s.preinstall || s.install)
+      hooks.push({ name: p, version: pkg.version, scripts: { postinstall: s.postinstall, preinstall: s.preinstall, install: s.install } });
+  } catch(e) {}
+}
+if (hooks.length === 0) {
+  console.log('PASS — no postinstall/preinstall/install hooks found');
+} else {
+  console.log('HOOKS FOUND — review each:');
+  hooks.forEach(h => console.log(JSON.stringify(h, null, 2)));
+}
+" 2>&1
+```
+
+For each hook, classify:
+- **[INFO] Known-safe** — well-known packages with legitimate build hooks (e.g. `esbuild`, native addon compilers).
+- **[HIGH] Unknown/suspicious** — package name not widely recognized, hook does network activity, or appeared unexpectedly.
+- **[CRITICAL] Malicious indicators** — downloads executables, references unknown domains, base64-decodes payloads.
+
+---
+
+## Step 4 — RAT Dropper Artifacts
+
+```bash
+ls -la /Library/Caches/com.apple.act.mond 2>/dev/null && echo "CRITICAL: RAT artifact found on macOS" || echo "macOS artifact: not present"
+crontab -l 2>/dev/null | grep -i "ld.py\|wt.exe\|act.mond" || echo "crontab: clean"
+```
+
+**If any artifact is found:** Report [CRITICAL] immediately. Do NOT run any more npm commands. Instruct the user to isolate the machine, rotate all credentials (npm token, GitHub PAT), and rebuild from a clean snapshot. C2 blocklist: `sfrclak.com` / `142.11.206.73`.
+
+---
+
+## Step 5 — CI Uses npm ci --ignore-scripts
+
+Read `.github/workflows/` files. Check that CI never uses bare `npm install`:
+
+```bash
+grep -rn "npm install" .github/workflows/ || echo "No bare npm install found"
+grep -rn "npm ci" .github/workflows/ || echo "No npm ci found"
+```
+
+**Pass:** All CI steps use `npm ci --ignore-scripts`.
+**Fail [HIGH]:** Any step using bare `npm install` instead.
+
+---
+
+## Step 6 — Lockfile Committed
+
+```bash
+git ls-files package-lock.json
+```
+
+**Pass:** `package-lock.json` is tracked.
+**Fail [HIGH]:** Not committed — the lockfile is the integrity record.
+
+---
+
+## Step 7 — New Package Pre-Import Checklist
+
+If invoked because the user is about to add a new package, run this checklist before allowing install:
+
+1. Does the package exist on npmjs.com with a credible publish history?
+2. When was the last publish? Has ownership changed recently?
+3. How many transitive dependencies does it pull in? (More than 5 is a yellow flag; more than 20 needs justification)
+4. Does its `package.json` have a `scripts.postinstall`? If yes, read it and explain exactly what it does.
+5. Will the version be pinned exactly (no `^` or `~`)?
+
+---
+
+## Output Format
+
+```
+SUPPLY CHAIN AUDIT REPORT
+==========================
+Date: <date>
+Trigger: <pre-install check / routine audit / post npm install>
+
+## Step 1 — Version Pin Audit
+PASS — all N packages exactly pinned
+  OR
+[CRITICAL] N floating pins: <list>
+
+## Step 2 — Unexpected Transitive Dependencies
+PASS — lockfile matches HEAD, no unexpected packages
+  OR
+[CRITICAL] N unexpected packages appeared: <list>
+
+## Step 3 — Postinstall Hook Audit
+PASS — no hooks found
+  OR
+[INFO] Known-safe: <package> (reason)
+[HIGH] Unknown hook: <package> — postinstall: "<script>"
+
+## Step 4 — RAT Dropper Artifacts
+PASS — no known RAT artifacts found
+  OR
+[CRITICAL] ARTIFACT FOUND — isolate machine, rotate all credentials immediately
+
+## Step 5 — CI npm Usage
+PASS — all workflows use npm ci --ignore-scripts
+  OR
+[HIGH] <workflow file>:<line> — bare npm install found
+
+## Step 6 — Lockfile Committed
+PASS — package-lock.json is tracked by git
+  OR
+[HIGH] package-lock.json is NOT committed
+
+---
+
+## Verdict
+CLEAN — no supply chain attack indicators found.
+  OR
+ACTION REQUIRED — fix the issues above before installing or committing.
+  OR
+CRITICAL THREAT — possible active compromise. Do not proceed. See Step 4 output.
+```
+
+---
+
+## When to Invoke
+
+- **Before adding any new npm package** — mandatory, run before `npm install <package>`
+- **After any `npm install` not fully controlled** — e.g. after pulling a branch someone else updated
+- **After any dependency update**
+- **As part of `/pre-commit`** if `package.json` or `package-lock.json` changed


### PR DESCRIPTION
## Summary
- Adds 20 project-specific Claude Code slash commands to `.claude/commands/`
- Adapted from a general-purpose skill library to this TypeScript VS Code extension codebase
- Pure tooling addition — zero source code changes, zero test changes, zero dependency changes

## Issue
Closes #43

## Changes
`.claude/commands/` — 20 new markdown command files:

**Core workflow:**
- `/pre-commit` — full CLAUDE.md checklist with dual-backend sync gate
- `/jidoka` — bug → countermeasure test → minimal fix
- `/pr-flow` — full ship pipeline (pre-commit → PR → reviews → ToC)

**Code quality:**
- `/code-review` — triple review: architecture, perf, security
- `/contract-test` — IRecipeFakerService/IFakerRecipeProcessor parity between both faker backends
- `/debug-audit` — debugger statements, console.log in services, temp markers

**Security:**
- `/security-review` — CI/CD, supply chain, command injection, XML parsing, vsce token
- `/supply-chain-check` — postinstall hooks, floating pins, unexpected transitive deps

**Project management:**
- `/new-issue` — structured GitHub issue creation with codebase impact exploration
- `/criteria-check` — verify acceptance criteria against the build
- `/next-task` — pick up an issue, create branch, implement
- `/project-sync` — verify issue/PR/branch alignment
- `/pr-body` — PR table of contents aggregating all skill verdicts
- `/pr-diagram` — mermaid before/after pipeline flow diagrams

**Validation:**
- `/deploy-check` — vsce package, manifest, .vscodeignore, CI alignment
- `/diagram-check` — detect stale CLAUDE.md project structure
- `/docs-check` — CHANGELOG, README, CLAUDE.md currency

**Performance & exploration:**
- `/perf-review` — activation time, sync I/O, XML at scale
- `/debug-tour` — CodeTour for current branch diff
- `/generate-tour` — CodeTour for any subsystem

## Checklist
- [x] `npm run compile` — zero errors (non-code change)
- [x] `npm run jest-test` — all tests pass (non-code change)
- [x] All commands reference correct project paths and scripts
- [x] No source code, test, or dependency changes