### PR TITLE
feat: add customRelationshipMappings config for custom lookup hierarchy resolution (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Change Log
 
+## [2.10.0] - Custom Relationship Mappings for Lookup Field Hierarchy Resolution
+
+Resolves [#47](https://github.com/jdschleicher/Salesforce-Data-Treecipe/issues/47).
+
+### 🎯 Major Features
+
+#### 1. **`customRelationshipMappings` Config Property**
+
+`treecipe.config.json` now supports an optional `customRelationshipMappings` property — a flat map keyed by `"ObjectApiName.FieldApiName"` whose value is the parent object API name. This lets developers manually resolve custom lookup fields whose XML metadata is missing the `<referenceTo>` tag, so those objects get grouped into the correct relationship tree and Treecipe files are generated with the right insertion order.
+
+**Example:**
+
+```json
+{
+    "salesforceObjectsPath": "force-app/main/default/objects",
+    "dataFakerService": "snowfakery",
+    "customRelationshipMappings": {
+        "CustomObject__c.Primary_Contact__c": "Contact",
+        "Project__c.Owner_Account__c": "Account"
+    }
+}
+```
+
+#### 2. **OOTB Map is Always Preserved**
+
+Custom entries **extend**, never override, the built-in OOTB map (`AccountId → Account`). Lookup resolution checks the full `ObjectApiName.FieldApiName` key in the custom map first, then falls back to OOTB by `FieldApiName`. If a custom entry collides with an OOTB key, OOTB wins.
+
+#### 3. **Graceful Handling of Invalid Keys**
+
+Malformed custom keys (missing dot separator, empty object/field segment, multiple dots) are silently skipped — no crash, behavior matches the pre-existing "no relationship resolved" outcome.
+
+### 🔧 Technical Details
+
+- New `ConfigurationService.getCustomRelationshipMappings()` static getter — returns `{}` when the property is absent or null
+- New `TreecipeConfigDetail.customRelationshipMappings?: Record<string, string>` interface field
+- New `RelationshipService.getMergedReferenceLookupMap(customRelationshipMappings)` — returns OOTB map merged with valid custom entries
+- New `RelationshipService.resolveParentReferenceForField(objectApiName, fieldApiName, customRelationshipMappings)` — resolves a parent for a Lookup/MasterDetail/Hierarchy field, custom-first, OOTB fallback
+- `DirectoryProcessor` lazy-loads custom mappings once per processor instance and consults them at lookup-resolution time when XML `<referenceTo>` is absent
+- Unit tests added for `ConfigurationService.getCustomRelationshipMappings` (present, absent, null)
+- Unit tests added for `RelationshipService.getMergedReferenceLookupMap` and `resolveParentReferenceForField` (OOTB-only, custom extends OOTB, OOTB never overridden, invalid keys skipped, fallback chain)
+
+### 🧭 Out of Scope (Tracked Separately)
+
+- Recipe YAML field-level content generation for custom lookup fields (`friends` block / dynamic relationship references)
+- Distinguishing `Lookup` vs `MasterDetail` field types in custom mappings
+- Overriding OOTB entries with custom mappings
+- VS Code UI for editing custom mappings
+
+---
+
 ## [2.9.0][PR#37](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/37) - Mermaid ERD Dedicated File & MermaidService Extraction
 
 ### 🎯 Major Features

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Salesforce Data Treecipe",
   "description": "source-fidelity driven development, pairs well with cumulus-ci",
   "icon": "images/datatreecipe.webp",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/src/treecipe/src/ConfigurationService/ConfigurationService.ts
+++ b/src/treecipe/src/ConfigurationService/ConfigurationService.ts
@@ -20,6 +20,7 @@ export interface ExtensionConfig {
 export interface TreecipeConfigDetail {
     salesforceObjectsPath: string;
     dataFakerService: string;
+    customRelationshipMappings?: Record<string, string>;
 }
 
 export class ConfigurationService {
@@ -44,6 +45,18 @@ export class ConfigurationService {
 
         const configurationDetail = this.getTreecipeConfigurationDetail();
         return configurationDetail.salesforceObjectsPath;
+
+    }
+
+    static getCustomRelationshipMappings(): Record<string, string> {
+
+        const configurationDetail = this.getTreecipeConfigurationDetail();
+        const customRelationshipMappings = configurationDetail?.customRelationshipMappings;
+        if (!customRelationshipMappings || typeof customRelationshipMappings !== 'object') {
+            return {};
+        }
+
+        return customRelationshipMappings;
 
     }
 

--- a/src/treecipe/src/ConfigurationService/tests/ConfigurationService.test.ts
+++ b/src/treecipe/src/ConfigurationService/tests/ConfigurationService.test.ts
@@ -232,6 +232,73 @@ describe('Shared ConfigurationService Tests', () => {
 
     });
 
+    describe('getCustomRelationshipMappings', () => {
+
+        beforeEach(() => {
+            jest.clearAllMocks();
+        });
+
+        test('given config with customRelationshipMappings present, returns the mapping object', () => {
+
+            const expectedConfigDetailJson = `{
+    "salesforceObjectsPath": "/mock/objects/path",
+    "dataFakerService": "snowfakery",
+    "customRelationshipMappings": {
+        "CustomObject__c.Primary_Contact__c": "Contact",
+        "Project__c.Owner_Account__c": "Account"
+    }
+}`;
+
+            jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+            jest.spyOn(fs, 'readFileSync').mockReturnValue(expectedConfigDetailJson);
+            jest.spyOn(ConfigurationService, 'setExtensionConfigValue').mockReturnValue();
+
+            const actualMappings = ConfigurationService.getCustomRelationshipMappings();
+
+            expect(actualMappings).toEqual({
+                "CustomObject__c.Primary_Contact__c": "Contact",
+                "Project__c.Owner_Account__c": "Account"
+            });
+
+        });
+
+        test('given config without customRelationshipMappings property, returns empty object', () => {
+
+            const expectedConfigDetailJson = `{
+    "salesforceObjectsPath": "/mock/objects/path",
+    "dataFakerService": "snowfakery"
+}`;
+
+            jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+            jest.spyOn(fs, 'readFileSync').mockReturnValue(expectedConfigDetailJson);
+            jest.spyOn(ConfigurationService, 'setExtensionConfigValue').mockReturnValue();
+
+            const actualMappings = ConfigurationService.getCustomRelationshipMappings();
+
+            expect(actualMappings).toEqual({});
+
+        });
+
+        test('given config with customRelationshipMappings set to null, returns empty object', () => {
+
+            const expectedConfigDetailJson = `{
+    "salesforceObjectsPath": "/mock/objects/path",
+    "dataFakerService": "snowfakery",
+    "customRelationshipMappings": null
+}`;
+
+            jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+            jest.spyOn(fs, 'readFileSync').mockReturnValue(expectedConfigDetailJson);
+            jest.spyOn(ConfigurationService, 'setExtensionConfigValue').mockReturnValue();
+
+            const actualMappings = ConfigurationService.getCustomRelationshipMappings();
+
+            expect(actualMappings).toEqual({});
+
+        });
+
+    });
+
     describe('getObjectsPathFromTreecipeJSONConfiguration', () => {
 
         test('given mocked configuration, returns expected objects path.', () => {

--- a/src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts
+++ b/src/treecipe/src/DirectoryProcessingService/DirectoryProcessor.ts
@@ -19,10 +19,27 @@ export class DirectoryProcessor {
 
   private recipeService: RecipeService;
   private relationshipService: RelationshipService;
+  private customRelationshipMappings: Record<string, string> | undefined;
   constructor() {
     const selectedDataFakerService = ConfigurationService.getFakerImplementationByExtensionConfigSelection();
     this.recipeService = new RecipeService(selectedDataFakerService);
     this.relationshipService = new RelationshipService();
+  }
+
+  private getCustomRelationshipMappings(): Record<string, string> {
+
+    if (this.customRelationshipMappings !== undefined) {
+      return this.customRelationshipMappings;
+    }
+
+    try {
+      this.customRelationshipMappings = ConfigurationService.getCustomRelationshipMappings();
+    } catch {
+      this.customRelationshipMappings = {};
+    }
+
+    return this.customRelationshipMappings;
+
   }
 
   async processDirectory(directoryPathUri: vscode.Uri, objectInfoWrapper: ObjectInfoWrapper): Promise<ObjectInfoWrapper> {
@@ -77,11 +94,10 @@ export class DirectoryProcessor {
                 fieldDetail.fieldName
               );
 
-              if (fieldDetail.type === 'Lookup' 
-                    || fieldDetail.type === 'MasterDetail' 
+              if (fieldDetail.type === 'Lookup'
+                    || fieldDetail.type === 'MasterDetail'
                     || fieldDetail.type === 'Hiearchy') {
 
-                  const ootbFieldReferenceTolLookupApiNameMap = this.relationshipService.getOotbReferenceLookupMap();
                   let parentReferenceApiName = null;
                   if (fieldDetail.referenceTo) {
 
@@ -89,14 +105,19 @@ export class DirectoryProcessor {
 
                   } else {
 
-                    parentReferenceApiName = ootbFieldReferenceTolLookupApiNameMap[fieldDetail.fieldName];
+                    const customRelationshipMappings = this.getCustomRelationshipMappings();
+                    parentReferenceApiName = this.relationshipService.resolveParentReferenceForField(
+                      objectName,
+                      fieldDetail.fieldName,
+                      customRelationshipMappings
+                    );
 
                   }
 
                   if ( parentReferenceApiName ) {
                     objectInfoWrapper.ObjectToObjectInfoMap = this.relationshipService.buildBidirectionalChildAndParentRelationshipReferences(fieldDetail, objectInfoWrapper, objectName, parentReferenceApiName);
                   }
-                    
+
               }
 
 

--- a/src/treecipe/src/RelationshipService/RelationshipService.ts
+++ b/src/treecipe/src/RelationshipService/RelationshipService.ts
@@ -450,17 +450,85 @@ export class RelationshipService {
   }
 
   getOotbReferenceLookupMap(): Record<string, string> {
-    
+
     let ootbLookupReferenceToObjectApiNameMap: Record<string, string> | undefined;
     if (ootbLookupReferenceToObjectApiNameMap) {
       return ootbLookupReferenceToObjectApiNameMap;
     }
-    
+
     ootbLookupReferenceToObjectApiNameMap = {
       "AccountId": "Account"
     };
-    
+
     return ootbLookupReferenceToObjectApiNameMap;
+
+  }
+
+  getMergedReferenceLookupMap(customRelationshipMappings?: Record<string, string>): Record<string, string> {
+
+    const ootbMap = this.getOotbReferenceLookupMap();
+    const merged: Record<string, string> = { ...ootbMap };
+
+    if (!customRelationshipMappings) {
+      return merged;
+    }
+
+    for (const [customKey, parentObjectApiName] of Object.entries(customRelationshipMappings)) {
+
+      if (!this.isValidCustomRelationshipKey(customKey) || !parentObjectApiName) {
+        continue;
+      }
+
+      // OOTB entries always win — custom entries extend, never override
+      if (merged[customKey]) {
+        continue;
+      }
+
+      merged[customKey] = parentObjectApiName;
+
+    }
+
+    return merged;
+
+  }
+
+  resolveParentReferenceForField(
+    objectApiName: string,
+    fieldApiName: string,
+    customRelationshipMappings?: Record<string, string>
+  ): string | undefined {
+
+    const ootbMap = this.getOotbReferenceLookupMap();
+
+    if (customRelationshipMappings) {
+      const objectFieldKey = `${objectApiName}.${fieldApiName}`;
+      const customMatch = customRelationshipMappings[objectFieldKey];
+      if (customMatch && this.isValidCustomRelationshipKey(objectFieldKey)) {
+        return customMatch;
+      }
+    }
+
+    return ootbMap[fieldApiName];
+
+  }
+
+  private isValidCustomRelationshipKey(key: string): boolean {
+
+    if (!key || typeof key !== 'string') {
+      return false;
+    }
+
+    const dotIndex = key.indexOf('.');
+    if (dotIndex <= 0 || dotIndex === key.length - 1) {
+      return false;
+    }
+
+    // reject keys containing more than a single dot separator
+    if (key.indexOf('.', dotIndex + 1) !== -1) {
+      return false;
+    }
+
+    return true;
 
   }
 

--- a/src/treecipe/src/RelationshipService/tests/RelationshipService.test.ts
+++ b/src/treecipe/src/RelationshipService/tests/RelationshipService.test.ts
@@ -690,4 +690,199 @@ describe("Shared Relationship Service Tests", () => {
             expect(objectInfoWrapper.ObjectToObjectInfoMap['Order_Item__c'].RelationshipDetail.level).toBe(2);
         });
     });
+
+    describe('getMergedReferenceLookupMap', () => {
+
+        test('given no custom mappings, returns OOTB map only', () => {
+
+            const relationshipService = new RelationshipService();
+            const merged = relationshipService.getMergedReferenceLookupMap();
+
+            expect(merged).toEqual({ "AccountId": "Account" });
+
+        });
+
+        test('given undefined custom mappings, returns OOTB map only', () => {
+
+            const relationshipService = new RelationshipService();
+            const merged = relationshipService.getMergedReferenceLookupMap(undefined);
+
+            expect(merged).toEqual({ "AccountId": "Account" });
+
+        });
+
+        test('given empty custom mappings, returns OOTB map only', () => {
+
+            const relationshipService = new RelationshipService();
+            const merged = relationshipService.getMergedReferenceLookupMap({});
+
+            expect(merged).toEqual({ "AccountId": "Account" });
+
+        });
+
+        test('given valid custom mappings, returns OOTB map merged with custom entries', () => {
+
+            const relationshipService = new RelationshipService();
+            const customMappings = {
+                "CustomObject__c.Primary_Contact__c": "Contact",
+                "Project__c.Owner_Account__c": "Account"
+            };
+
+            const merged = relationshipService.getMergedReferenceLookupMap(customMappings);
+
+            expect(merged).toEqual({
+                "AccountId": "Account",
+                "CustomObject__c.Primary_Contact__c": "Contact",
+                "Project__c.Owner_Account__c": "Account"
+            });
+
+        });
+
+        test('given custom mapping that collides with an OOTB key, OOTB entry is preserved (custom does not override)', () => {
+
+            const relationshipService = new RelationshipService();
+            const customMappings = {
+                "AccountId": "SomeOtherObject__c"
+            };
+
+            const merged = relationshipService.getMergedReferenceLookupMap(customMappings);
+
+            expect(merged["AccountId"]).toBe("Account");
+
+        });
+
+        test('given invalid custom keys, invalid entries are skipped and valid entries are kept', () => {
+
+            const relationshipService = new RelationshipService();
+            const customMappings = {
+                "MissingDotKey": "Contact",
+                ".NoObjectPrefix__c": "Contact",
+                "NoFieldSuffix__c.": "Contact",
+                "Too.Many.Dots__c": "Contact",
+                "CustomObject__c.Primary_Contact__c": "Contact"
+            };
+
+            const merged = relationshipService.getMergedReferenceLookupMap(customMappings);
+
+            expect(merged).toEqual({
+                "AccountId": "Account",
+                "CustomObject__c.Primary_Contact__c": "Contact"
+            });
+
+        });
+
+        test('given custom mapping with empty parent value, entry is skipped', () => {
+
+            const relationshipService = new RelationshipService();
+            const customMappings = {
+                "CustomObject__c.Primary_Contact__c": ""
+            };
+
+            const merged = relationshipService.getMergedReferenceLookupMap(customMappings);
+
+            expect(merged).toEqual({ "AccountId": "Account" });
+
+        });
+
+    });
+
+    describe('resolveParentReferenceForField', () => {
+
+        test('given custom mapping for ObjectApiName.FieldApiName, returns mapped parent', () => {
+
+            const relationshipService = new RelationshipService();
+            const customMappings = {
+                "CustomObject__c.Primary_Contact__c": "Contact"
+            };
+
+            const parent = relationshipService.resolveParentReferenceForField(
+                'CustomObject__c',
+                'Primary_Contact__c',
+                customMappings
+            );
+
+            expect(parent).toBe('Contact');
+
+        });
+
+        test('given fieldName matches OOTB and no custom override, returns OOTB parent', () => {
+
+            const relationshipService = new RelationshipService();
+            const customMappings = {
+                "CustomObject__c.Primary_Contact__c": "Contact"
+            };
+
+            const parent = relationshipService.resolveParentReferenceForField(
+                'Contact',
+                'AccountId',
+                customMappings
+            );
+
+            expect(parent).toBe('Account');
+
+        });
+
+        test('given no custom mappings provided, falls back to OOTB lookup by fieldName', () => {
+
+            const relationshipService = new RelationshipService();
+
+            const parent = relationshipService.resolveParentReferenceForField(
+                'Contact',
+                'AccountId'
+            );
+
+            expect(parent).toBe('Account');
+
+        });
+
+        test('given undefined custom mappings, falls back to OOTB lookup by fieldName', () => {
+
+            const relationshipService = new RelationshipService();
+
+            const parent = relationshipService.resolveParentReferenceForField(
+                'Contact',
+                'AccountId',
+                undefined
+            );
+
+            expect(parent).toBe('Account');
+
+        });
+
+        test('given field that matches neither custom nor OOTB, returns undefined', () => {
+
+            const relationshipService = new RelationshipService();
+            const customMappings = {
+                "CustomObject__c.Primary_Contact__c": "Contact"
+            };
+
+            const parent = relationshipService.resolveParentReferenceForField(
+                'OtherObject__c',
+                'Some_Unknown_Field__c',
+                customMappings
+            );
+
+            expect(parent).toBeUndefined();
+
+        });
+
+        test('given object/field combination not in custom mappings, falls back to OOTB by fieldName when present', () => {
+
+            const relationshipService = new RelationshipService();
+            const customMappings = {
+                "CustomObject__c.Primary_Contact__c": "Contact"
+            };
+
+            // Field name "AccountId" used on a different object — not in custom map, but OOTB resolves by fieldName
+            const parent = relationshipService.resolveParentReferenceForField(
+                'OtherObject__c',
+                'AccountId',
+                customMappings
+            );
+
+            expect(parent).toBe('Account');
+
+        });
+
+    });
 });


### PR DESCRIPTION
Adds an optional `customRelationshipMappings` property to treecipe.config.json
keyed by "ObjectApiName.FieldApiName" with the parent object API name as the
value. Lets developers manually resolve custom lookup fields whose XML metadata
is missing <referenceTo>, so those objects are grouped into the correct
relationship tree and Treecipe files are generated with the right insertion
order. Custom entries extend, never override, the OOTB map; invalid keys are
silently skipped.

- ConfigurationService.getCustomRelationshipMappings() returns {} when absent
- RelationshipService.getMergedReferenceLookupMap merges OOTB + custom
- RelationshipService.resolveParentReferenceForField resolves custom-first,
  OOTB fallback by fieldName
- DirectoryProcessor lazy-loads custom mappings and consults them at lookup
  resolution time when XML referenceTo is absent

https://claude.ai/code/session_01VpRYWkEJUao4FHtxCTRhvV