### PR TITLE
Fix `.undefined/` directory quick pick items caused by deprecated fs.Dirent.path (DEP0178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [2.11.1] - Fix `.undefined/` directory quick pick items (deprecated fs.Dirent.path)
+
+Resolves [#51](https://github.com/jdschleicher/Salesforce-Data-Treecipe/issues/51).
+
+### Bug Fixes
+
+- Directory quick pick items in **Initiate Configuration File** (and the **Insert Data Set by Directory** dataset picker) rendered every folder as `.undefined/` instead of its relative path
+- Root cause: `VSCodeWorkspaceService.buildDirectoryVSCodeQuickPickItemByDirectoryEntry` derived the path from `fs.Dirent.path`, which is deprecated ([DEP0178](https://nodejs.org/api/deprecations.html)) in favor of `dirent.parentPath` and returns `undefined` in the Node runtime bundled with recent VS Code/Electron builds — no code change caused this; a runtime update surfaced it
+- The builder now takes the parent directory path from its caller (`getDirectoryQuickPickItemsByStartingDirectoryPath` / `getDataSetDirectoryQuickPickItemsByStartingDirectoryPath`) instead of reading the deprecated `Dirent.path`, making label generation runtime-independent
+- Added regression tests: `buildDirectoryVSCodeQuickPickItemByDirectoryEntry` produces a defined label when `Dirent.path` is `undefined`, and the recursive directory traversal builds a correct relative-path label without relying on `Dirent.path`
+
+---
+
 ## [2.11.0] - friends Block Processing in FakerJS Recipe Processor
 
 Resolves [#45](https://github.com/jdschleicher/Salesforce-Data-Treecipe/issues/45).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Resolves [#51](https://github.com/jdschleicher/Salesforce-Data-Treecipe/issues/5
 - Directory quick pick items in **Initiate Configuration File** (and the **Insert Data Set by Directory** dataset picker) rendered every folder as `.undefined/` instead of its relative path
 - Root cause: `VSCodeWorkspaceService.buildDirectoryVSCodeQuickPickItemByDirectoryEntry` derived the path from `fs.Dirent.path`, which is deprecated ([DEP0178](https://nodejs.org/api/deprecations.html)) in favor of `dirent.parentPath` and returns `undefined` in the Node runtime bundled with recent VS Code/Electron builds — no code change caused this; a runtime update surfaced it
 - The builder now takes the parent directory path from its caller (`getDirectoryQuickPickItemsByStartingDirectoryPath` / `getDataSetDirectoryQuickPickItemsByStartingDirectoryPath`) instead of reading the deprecated `Dirent.path`, making label generation runtime-independent
-- Added regression tests: `buildDirectoryVSCodeQuickPickItemByDirectoryEntry` produces a defined label when `Dirent.path` is `undefined`, and the recursive directory traversal builds a correct relative-path label without relying on `Dirent.path`
+- `getAvailableRecipeFileQuickPickItemsByDirectory` (the **Run Faker by Recipe** file picker) had the same deprecated `entry.path` dependency, where `path.join(undefined, ...)` would throw and break recipe file selection entirely; it now uses the in-scope `folderPathToParse`
+- Added regression tests: `buildDirectoryVSCodeQuickPickItemByDirectoryEntry` produces a defined label when `Dirent.path` is `undefined`, the recursive directory traversal builds a correct relative-path label without relying on `Dirent.path`, and the recipe file picker builds a correct `detail` path when `Dirent.path` is `undefined`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Salesforce Data Treecipe",
   "description": "source-fidelity driven development, pairs well with cumulus-ci",
   "icon": "images/datatreecipe.webp",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "engines": {
     "vscode": "^1.94.0"
   },

--- a/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts
+++ b/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts
@@ -63,7 +63,7 @@ export class VSCodeWorkspaceService {
   
             if ( this.isPossibleTreecipeUsableDirectory(entry) ) {
 
-                const quickPickDirectoryItem = this.buildDirectoryVSCodeQuickPickItemByDirectoryEntry(entry, workspaceRoot);
+                const quickPickDirectoryItem = this.buildDirectoryVSCodeQuickPickItemByDirectoryEntry(entry, workspaceRoot, directoryPath);
                 quickPickItems.push(quickPickDirectoryItem);
 
                 const fullPath = path.join(directoryPath, entry.name);
@@ -97,11 +97,11 @@ export class VSCodeWorkspaceService {
 
             if ( isFakerJSDatasetWhenFakerJSSelected || isSnowfakeryDatasetWhenSnowfakerySelected ) {
 
-                const quickPickDirectoryItem = this.buildDirectoryVSCodeQuickPickItemByDirectoryEntry(entry, workspaceRoot);
+                const quickPickDirectoryItem = this.buildDirectoryVSCodeQuickPickItemByDirectoryEntry(entry, workspaceRoot, directoryPath);
                 quickPickItems.push(quickPickDirectoryItem);
 
             }
-  
+
         }
       
         return quickPickItems;
@@ -121,9 +121,11 @@ export class VSCodeWorkspaceService {
         return folderName.startsWith('.');
     }
 
-    static buildDirectoryVSCodeQuickPickItemByDirectoryEntry(entry: fs.Dirent, workspaceRoot: string) {
-        
-        const fullMachinePathToEntry = entry.path;
+    static buildDirectoryVSCodeQuickPickItemByDirectoryEntry(entry: fs.Dirent, workspaceRoot: string, parentDirectoryPath: string) {
+
+        // parentDirectoryPath is supplied by the caller rather than read from the deprecated
+        // fs.Dirent.path (DEP0178), which returns undefined in recent Electron/Node runtimes
+        const fullMachinePathToEntry = parentDirectoryPath;
         const currentDirectoryName = entry.name;
 
         const fullEntryPath = `${fullMachinePathToEntry}/${currentDirectoryName}`;

--- a/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts
+++ b/src/treecipe/src/VSCodeWorkspace/VSCodeWorkspaceService.ts
@@ -220,8 +220,11 @@ export class VSCodeWorkspaceService {
                     continue;
                 }
 
-                const quickpickLabel = `${entry.name}`; 
-                const fullFilePathName = path.join(entry.path, entry.name);
+                const quickpickLabel = `${entry.name}`;
+                // folderPathToParse (the readdir argument) is the entry's parent directory; the
+                // deprecated fs.Dirent.path (DEP0178) returns undefined in recent Electron/Node
+                // runtimes, and path.join(undefined, ...) would throw
+                const fullFilePathName = path.join(folderPathToParse, entry.name);
                 recipeFileQuickPickItems.push({
                     label: quickpickLabel,
                     description: 'File',

--- a/src/treecipe/src/VSCodeWorkspace/tests/VSCodeWorkspaceService.test.ts
+++ b/src/treecipe/src/VSCodeWorkspace/tests/VSCodeWorkspaceService.test.ts
@@ -337,6 +337,31 @@ describe('Shared VSCodeWorkspaceService unit tests', () => {
 
         });
 
+        test('given file Dirents whose deprecated path property is undefined, builds detail from folderPathToParse without throwing', async () => {
+
+            const folderPathToParse = '/mock/generated-recipes';
+
+            // path/parentPath intentionally omitted to mirror the DEP0178 runtime where
+            // fs.Dirent.path is undefined; path.join(undefined, name) would otherwise throw
+            const mockDirents = [
+                Object.assign(new fs.Dirent(), {
+                    name: 'recipe1.yaml',
+                    isFile: () => true
+                }),
+            ];
+
+            jest.spyOn(fs.promises, 'readdir').mockResolvedValue(mockDirents);
+            jest.spyOn(ConfigurationService, 'getExtensionConfigValue').mockReturnValue('snowfakery');
+
+            let emptyQuickPickItems: vscode.QuickPickItem[] = [];
+            const actualQuickPickItems = await VSCodeWorkspaceService.getAvailableRecipeFileQuickPickItemsByDirectory(emptyQuickPickItems, folderPathToParse);
+
+            expect(actualQuickPickItems).toHaveLength(1);
+            expect(actualQuickPickItems[0].detail).toBe('/mock/generated-recipes/recipe1.yaml');
+            expect(actualQuickPickItems[0].detail).not.toContain('undefined');
+
+        });
+
 
         test('given faker-js as selected faker service and directories with both fakerjs recipes and snowfakery, should return expected QuickPickItems for each file found', async () => {
                           

--- a/src/treecipe/src/VSCodeWorkspace/tests/VSCodeWorkspaceService.test.ts
+++ b/src/treecipe/src/VSCodeWorkspace/tests/VSCodeWorkspaceService.test.ts
@@ -111,7 +111,35 @@ describe('Shared VSCodeWorkspaceService unit tests', () => {
 
             // TEST IS SETUP TO AVOID RECURSIVE
             expect(result.length).toEqual(0);
-            
+
+        });
+
+        test('given a directory entry, builds a relative-path label from the traversed directoryPath rather than the deprecated Dirent.path', async () => {
+
+            const mockWorkspaceRoot = '/mockWorkspace';
+            const startingDirectoryPath = `${mockWorkspaceRoot}/force-app/main/default`;
+
+            // Dirent intentionally has no path/parentPath to mirror the DEP0178 runtime where
+            // fs.Dirent.path is undefined; the label must still resolve from directoryPath
+            const objectsDirent = Object.assign(new fs.Dirent(), {
+                name: 'objects',
+                isDirectory: () => true
+            });
+
+            jest.spyOn(VSCodeWorkspaceService, 'getWorkspaceRoot').mockReturnValue(mockWorkspaceRoot);
+            jest.spyOn(fs.promises, 'readdir')
+                .mockResolvedValueOnce([objectsDirent] as unknown as fs.Dirent[])
+                .mockResolvedValueOnce([] as unknown as fs.Dirent[]);
+            const mockIcon = new vscode.ThemeIcon('folder');
+            jest.spyOn(vscode, "ThemeIcon").mockReturnValue(mockIcon);
+
+            const result = await VSCodeWorkspaceService.getPotentialTreecipeObjectDirectoryPathsQuickPickItems(startingDirectoryPath);
+
+            expect(result.length).toEqual(1);
+            expect(result[0].label).toBe('./force-app/main/default/objects/');
+            expect(result[0].label).not.toContain('undefined');
+            expect(result[0].detail).toBe(`${startingDirectoryPath}/objects`);
+
         });
 
     });
@@ -473,23 +501,22 @@ describe('Shared VSCodeWorkspaceService unit tests', () => {
     describe('buildDirectoryVSCodeQuickPickItemByDirectoryEntry', () => {
         
         test('given expected arguments and mocked out modules, should build the correct quickPickItem', () => {
-            
+
             const fakeWorkspaceRoot = '/mock/workspace/root';
             const fakeDirectoryName = 'fakeDirectory';
             const pathToFakeDirectory = 'mock/path/to/entry';
-            const rootPathToFakeDirectory = `${fakeWorkspaceRoot}/${pathToFakeDirectory}`;
-            
+            const parentDirectoryPath = `${fakeWorkspaceRoot}/${pathToFakeDirectory}`;
+
             const mockDirent = {
-                path: rootPathToFakeDirectory, 
-                name: fakeDirectoryName, 
+                name: fakeDirectoryName,
             } as fs.Dirent;
-    
-    
+
+
             const mockIcon = new vscode.ThemeIcon('folder');
             jest.spyOn(vscode, "ThemeIcon").mockReturnValue(mockIcon);
 
-            const actualQuickPickItemEntry = VSCodeWorkspaceService.buildDirectoryVSCodeQuickPickItemByDirectoryEntry(mockDirent, fakeWorkspaceRoot);
-    
+            const actualQuickPickItemEntry = VSCodeWorkspaceService.buildDirectoryVSCodeQuickPickItemByDirectoryEntry(mockDirent, fakeWorkspaceRoot, parentDirectoryPath);
+
             const fullFakePath = `${fakeWorkspaceRoot}/${pathToFakeDirectory}/${fakeDirectoryName}`;
             const fakeRelativePath = `./${pathToFakeDirectory}/${fakeDirectoryName}/`;
             expect(actualQuickPickItemEntry).toEqual({
@@ -498,6 +525,27 @@ describe('Shared VSCodeWorkspaceService unit tests', () => {
                 iconPath: mockIcon,
                 detail: fullFakePath,
             });
+
+        });
+
+        test('given a Dirent whose deprecated path property is undefined, should still build a defined label from the caller-supplied parent path', () => {
+
+            const fakeWorkspaceRoot = '/mock/workspace/root';
+            const fakeDirectoryName = 'objects';
+            const parentDirectoryPath = `${fakeWorkspaceRoot}/force-app/main/default`;
+
+            const mockDirent = {
+                path: undefined,
+                name: fakeDirectoryName,
+            } as unknown as fs.Dirent;
+
+            const mockIcon = new vscode.ThemeIcon('folder');
+            jest.spyOn(vscode, "ThemeIcon").mockReturnValue(mockIcon);
+
+            const actualQuickPickItemEntry = VSCodeWorkspaceService.buildDirectoryVSCodeQuickPickItemByDirectoryEntry(mockDirent, fakeWorkspaceRoot, parentDirectoryPath);
+
+            expect(actualQuickPickItemEntry.label).toBe('./force-app/main/default/objects/');
+            expect(actualQuickPickItemEntry.label).not.toContain('undefined');
 
         });
 
@@ -517,15 +565,17 @@ describe('Shared VSCodeWorkspaceService unit tests', () => {
             jest.spyOn(vscode, "ThemeIcon").mockReturnValue(mockIcon);
        
             const quickPickItems: vscode.QuickPickItem[] = [];
-            const directoryPath = '/mock/directory/path';
+            // the directory being read is the shared parent of every entry; it lives under the
+            // workspace root so the derived relative-path label resolves correctly
+            const directoryPath = 'theworkspaceroot/andotherthings';
 
             jest.spyOn(ConfigurationService, "getSelectedDataFakerServiceConfig").mockReturnValue("snowfakery");
 
             const actualDataSetQuickPickItems = await VSCodeWorkspaceService.getDataSetDirectoryQuickPickItemsByStartingDirectoryPath(directoryPath, quickPickItems);
-    
+
             expect(fs.promises.readdir).toHaveBeenCalledWith(directoryPath, { withFileTypes: true });
             expect(VSCodeWorkspaceService.getWorkspaceRoot).toHaveBeenCalled();
-            
+
             const expectedQuickPickItems = [
                 {
                     "label": "./andotherthings/dataset-foldernameone/rest-ofdirectoryname/",
@@ -569,12 +619,14 @@ describe('Shared VSCodeWorkspaceService unit tests', () => {
             jest.spyOn(vscode, "ThemeIcon").mockReturnValue(mockIcon);
        
             const quickPickItems: vscode.QuickPickItem[] = [];
-            const directoryPath = '/mock/directory/path';
+            // the directory being read is the shared parent of every entry; it lives under the
+            // workspace root so the derived relative-path label resolves correctly
+            const directoryPath = 'theworkspaceroot/andotherthings';
 
             jest.spyOn(ConfigurationService, "getSelectedDataFakerServiceConfig").mockReturnValue("faker-js");
 
             const actualDataSetQuickPickItems = await VSCodeWorkspaceService.getDataSetDirectoryQuickPickItemsByStartingDirectoryPath(directoryPath, quickPickItems);
-    
+
             expect(fs.promises.readdir).toHaveBeenCalledWith(directoryPath, { withFileTypes: true });
             expect(VSCodeWorkspaceService.getWorkspaceRoot).toHaveBeenCalled();
             


### PR DESCRIPTION
## 📑 PR Navigation

| Section / Report | Verdict |
|------------------|---------|
| [Summary](#summary) | — |
| [🔍 TypeScript Review](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/52#issuecomment-4899339041) | ✅ APPROVE (after fix) |
| [⚡ Performance Review](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/52#issuecomment-4899339113) | ✅ APPROVE |
| [🔒 Security Review](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/52#issuecomment-4899339166) | ✅ PASS |
| [📊 PR Diagram](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/52#issuecomment-4899346744) | — |
| [✅ Criteria Check](https://github.com/jdschleicher/Salesforce-Data-Treecipe/pull/52#issuecomment-4899346793) | ✅ ALL MET |

---

## Summary
Directory quick pick items in **Initiate Configuration File** (and the **Insert Data Set by Directory** picker) rendered every folder as `.undefined/` instead of its relative path. The label was built from `fs.Dirent.path`, which is deprecated ([DEP0178](https://nodejs.org/api/deprecations.html)) in favor of `dirent.parentPath` and returns `undefined` in the Node runtime bundled with recent VS Code/Electron builds. No code changed — a runtime update surfaced it (the `entry.path` line is unchanged since 2024-10-23).

## Issue
Closes #51

## Changes
- `VSCodeWorkspaceService.buildDirectoryVSCodeQuickPickItemByDirectoryEntry` now takes the parent directory path from its caller instead of reading the deprecated `fs.Dirent.path`, making label generation runtime-independent
- Both callers — `getDirectoryQuickPickItemsByStartingDirectoryPath` and `getDataSetDirectoryQuickPickItemsByStartingDirectoryPath` — pass their `directoryPath` through
- **Code-review follow-up:** `getAvailableRecipeFileQuickPickItemsByDirectory` (the **Run Faker by Recipe** file picker) had the same `entry.path` bug where `path.join(undefined, ...)` would *throw*; now uses the in-scope `folderPathToParse`
- Regression tests added for all three undefined-`path` paths
- CHANGELOG + version bump to 2.11.1 (patch)

## Test Plan
- [x] `npm run compile` — zero errors
- [x] `npm run jest-test` — 355/355 pass, coverage not regressed
- [x] `npm run lint` — zero errors
- [x] `vsce package` — builds successfully (2.11.1.vsix)
- [ ] Manual: run **Initiate Configuration File** in VS Code and confirm quick pick shows real relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
